### PR TITLE
Update LDAPHelper reference.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,141 @@
-# LDAP Web Api (Bitai) ![Logo](resources/api1_32.png)
+# Bitai LDAP Web API Ecosystem
 
-**.NET 8.0** Web Api to authenticate, search, create, remove users on one or more **LDAP Servers**
-> The application is written in the **Asp.Net Core MVC** 
+[![.NET Core](https://img.shields.io/badge/.NET-8.0-blue.svg)](https://dotnet.microsoft.com)
+[![ASP.NET Core Web API](https://img.shields.io/badge/ASP.NET%20Core-Web%20API-green.svg)]()
+[![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20Linux-lightgrey.svg)]()
 
+An enterprise-grade, cross-platform **ASP.NET Core Web API** and client ecosystem designed to centralize and simplify operations across one or more **LDAP and Microsoft Active Directory Servers**. 
 
+The solution decouples direct network directory integrations by introducing a robust HTTP REST proxy layer. It supports secure authentication, highly optimized directory searching, and complete Active Directory user provisioning.
 
-## Requirements
+---
 
-- **.NET 8.0**
-  - Have the latest [.NET 7.0 SDK installed](https://dotnet.microsoft.com/download/dotnet/7.0) on your system.  
+## 🏛️ Solution Architecture & Component Layout
 
+The solution is divided into highly cohesive, decoupled components:
 
+```mermaid
+graph TD
+    ClientApp[Client Application] -->|HTTP REST / OAuth2| WebAPI[Bitai.LDAPWebApi]
+    
+    subgraph Clients Library Component
+        ClientApp -.->|Consumes| ClientLib[Bitai.LDAPWebApi.Client]
+    end
 
-## Documentation in progress...
+    subgraph Web API Service Layer
+        WebAPI -->|Uses| WebAPIDTO[Bitai.LDAPWebApi.DTO]
+        WebAPI -->|Adapts| LDAPHelper[Bitai.LDAPHelper]
+    end
 
-- Documentation in progress...
-- You can take a look at the **Bitai.LDAP Web Api.Demo** project for a reference on how to use the API.
+    subgraph Directory Infrastructure
+        LDAPHelper -->|LDAP / ldaps| AD[Active Directory Server A]
+        LDAPHelper -->|LDAP / ldaps| OpenLDAP[OpenLDAP Server B]
+    end
+```
+
+### 1. `Bitai.LDAPWebApi` (Service Host)
+*   **Technology**: ASP.NET Core MVC (Targeting .NET 8.0)
+*   **Role**: Host controller services exposing the directory proxy layer.
+*   **Configuration**: Manages multi-tenant LDAP configurations under custom profiles via `appsettings.json`.
+*   **Security**: Secured by OAuth2/Bearer authorization protocols (OAuth2 server, Identity Server, etc.).
+
+### 2. `Bitai.LDAPWebApi.DTO` (Contracts)
+*   **Role**: Defines the network models and transfer objects exchanged between clients and the Web API service (e.g., `LDAPServerProfile`, `LDAPServerCatalogTypes`).
+
+### 3. `Bitai.LDAPWebApi.Client` (Client Wrapper)
+*   **Role**: A strongly-typed C# library exposing client wrappers (`LDAPUserDirectoryWebApiClient`, `LDAPAuthenticationsWebApiClient`, `LDAPServerProfilesWebApiClient`, etc.) to integrate functionality into external client systems without writing HTTP handlers.
+
+### 4. `Bitai.LDAPWebApi.Client.Demo` (Reference Program)
+*   **Role**: Interactive demo application serving as a codebase reference for developer integrations.
+
+---
+
+## ✨ Features & Functionality
+
+### 🔒 Enterprise Directory Authentication
+Secure verification of directory credentials over traditional Domain accounts or raw Distinguished Names (DNs), returning structured authentication schemas including full membership roles.
+
+### 🔍 Optimized Directory Searches
+Perform complex search operations with multi-attribute filtering. Search payloads are fully optimized to retrieve only the required attributes (`Minimum`, `Few`, `All`), saving server bandwidth and client-side processing memory.
+
+### 👤 Microsoft Active Directory Provisioning
+Complete user state management over Active Directory:
+*   Provisions new `LDAPMsADUserAccount` entries.
+*   Performs secure password resets and updates (`unicodePwd` manipulation).
+*   Enables/disables account states using native Active Directory `UserAccountControl` (UAC) bitwise flags.
+*   Safely purges or removes user accounts.
+
+### 🖥️ Multi-Server Profiles
+Configure and balance queries across multiple independent directory infrastructures (e.g., local server profiles, global catalogs) concurrently using unique client context routes:
+`/api/{serverProfile}/{catalogType}/[controller]`
+
+---
+
+## 🗺️ Web API Endpoint Catalog
+
+The API exposes the following RESTful paths:
+
+| Controller | HTTP Verb | Route | Description |
+| :--- | :--- | :--- | :--- |
+| **`Authentications`** | `POST` | `/api/{profile}/{catalog}/Authentications/authenticate` | Validates domain user credentials. |
+| **`Directory`** | `GET` | `/api/{profile}/{catalog}/Directory/{identifier}` | Retrieves a general LDAP entry by unique ID. |
+| | `GET` | `/api/{profile}/{catalog}/Directory/filterBy` | Search directory entries using attribute filters. |
+| | `GET` | `/api/{profile}/{catalog}/Directory/Users/filterBy` | Search user entries using custom attributes. |
+| | `POST` | `/api/{profile}/{catalog}/Directory/MsADUsers` | Creates a new Active Directory User account. |
+| | `PATCH` | `/api/{profile}/{catalog}/Directory/MsADUsers/{id}/Credential` | Changes or assigns passwords in Active Directory. |
+| | `PATCH` | `/api/{profile}/{catalog}/Directory/MsADUsers/{id}/disableBy` | Disables an Active Directory User account. |
+| | `DELETE` | `/api/{profile}/{catalog}/Directory/MsADUsers/{id}` | Deletes a user account from Active Directory. |
+| | `GET` | `/api/{profile}/{catalog}/Directory/Groups/{identifier}` | Retrieves an LDAP group entry by identifier. |
+| | `GET` | `/api/{profile}/{catalog}/Directory/Groups/filterBy` | Queries LDAP groups using conditional filters. |
+| **`CatalogTypes`** | `GET` | `/api/CatalogTypes` | Lists all catalog categories supported. |
+| **`ServerProfiles`** | `GET` | `/api/ServerProfiles` | Lists configured active LDAP server profiles. |
+
+---
+
+## ⚙️ Configuration Setup
+
+Configure multiple LDAP profile connections inside `appsettings.json` of the **`Bitai.LDAPWebApi`** project:
+
+```json
+{
+  "LDAPProfiles": {
+    "DefaultActiveDirectory": {
+      "Host": "ad.company.local",
+      "Port": 389,
+      "BaseDn": "DC=company,DC=local",
+      "Credentials": {
+        "UserDn": "CN=LdapProxyUser,OU=ServiceAccounts,DC=company,DC=local",
+        "Password": "SuperSecretProxyPassword123!"
+      }
+    },
+    "BackupDirectory": {
+      "Host": "ad-backup.company.local",
+      "Port": 636,
+      "BaseDn": "DC=company,DC=local",
+      "UseSsl": true
+    }
+  }
+}
+```
+
+---
+
+## 🛠️ Build & Run Instructions
+
+To compile and launch the main Web API locally, execute the following commands in the root of the solution:
+
+### 1. Restore & Build
+```bash
+dotnet restore
+dotnet build --configuration Release
+```
+
+### 2. Run Main Web API
+```bash
+dotnet run --project src/LDAPWebApi/LDAPWebApi.csproj
+```
+
+The server will initialize its hosts, and the API endpoints will become available for the consumer client application.
+
+---
+

--- a/client/LDAPWebApi.Client.Demo/Bitai.LDAPWebApi.Clients.Demo.csproj
+++ b/client/LDAPWebApi.Client.Demo/Bitai.LDAPWebApi.Clients.Demo.csproj
@@ -5,12 +5,11 @@
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Bitai.LDAPWebApi.Clients.Demo</RootNamespace>
     <AssemblyName>Bitai.LDAPWebApi.Clients.Demo</AssemblyName>
-    <PackageId>LDAPProxyWebApi.Client.Demo</PackageId>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <AssemblyVersion>8.0.2.7</AssemblyVersion>
-    <FileVersion>8.0.2.7</FileVersion>
-    <Version>8.0.2</Version>
+    <AssemblyVersion>8.6.0.0</AssemblyVersion>
+    <FileVersion>8.6.0.0</FileVersion>
+    <Version>8.6.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/client/LDAPWebApi.Client.Demo/Program.cs
+++ b/client/LDAPWebApi.Client.Demo/Program.cs
@@ -19,23 +19,23 @@ namespace Bitai.LDAPWebApi.Clients.Demo
 			ServerCertificateCustomValidationCallback = (message, cert, chain, sslPolicyErrors) => true
 		};
 
-        static string WebApiBaseUrl = "https://localhost:5101";
-        static WebApiClientCredential ClientCredentials = new WebApiClientCredential
-        {
-            AuthorityUrl = "https://localhost:44310",
-            ApiScope = "VISIVA_LWA_Reader_ApiScope",
-            ClientId = "VISIVA_ISSTS_Reader_Client_for_LDAPWebApi",
-            ClientSecret = "17011981"
-        };
+		static string WebApiBaseUrl = "https://localhost:5101";
+		static WebApiClientCredential ClientCredentials = new WebApiClientCredential
+		{
+			AuthorityUrl = "https://localhost:44310",
+			ApiScope = "VISIVA_LWA_Reader_ApiScope",
+			ClientId = "VISIVA_ISSTS_Reader_Client_for_LDAPWebApi",
+			ClientSecret = "17011981"
+		};
 
-        static bool WebApiRequiresAccessToken = true;
-
-
+		static bool WebApiRequiresAccessToken = false;
 
 
-        static string RequestLabel { get; set; } = "DEMO";
 
-		static string Selected_LDAPServerProfile { get; set; } = "CERTUS-ADM";
+
+		static string RequestLabel { get; set; } = "DEMO";
+
+		static string Selected_LDAPServerProfile { get; set; } = "BITAIVA";
 
 
 
@@ -53,15 +53,15 @@ namespace Bitai.LDAPWebApi.Clients.Demo
 
 				await ServerProfilesClient_GetProfileIdsAsync();
 
-				//await ServerProfilesClient_GetAllAsync();
+				await ServerProfilesClient_GetAllAsync();
 
-				//await CatalogTypesClient_GetAllAsync();
+				await CatalogTypesClient_GetAllAsync();
 
 				//await UserDirectoryClient_CreateMsADUserAccountAsync();
 
 				//await UserDirectoryClient_SetMsADUserAccountPassword();
 
-				//await AuthenticationsClient_AccountAuthenticationAsync();
+				await AuthenticationsClient_AccountAuthenticationAsync();
 
 				//await UserDirectoryClient_DisableMsADUserAccount();
 
@@ -69,7 +69,7 @@ namespace Bitai.LDAPWebApi.Clients.Demo
 
 				//await DirectoryClient_SearchByIdentifierAsync();
 
-				//await UserDirectoryClient_FilterByIdentifierAsync("vbastidas");
+				await UserDirectoryClient_FilterByIdentifierAsync("victor.bastidas");
 
 				//await UserDirectoryClient_FilterByIdentifierAsync("??????");
 			}
@@ -201,10 +201,10 @@ namespace Bitai.LDAPWebApi.Clients.Demo
 
 				LogInfoOfType(client.GetType());
 
-				Console.WriteLine($"Enter the password of the CERTUS\\vbastidas account.");
+				Console.WriteLine($"Enter the password of the account.");
 				Console.WriteLine("(It is not nescessary to enter the real password)");
 
-				var accountCredentials = new LDAPHelper.DTO.LDAPDomainAccountCredential("CERTUS", "vbastidas", requestAccountPassword("CERTUS\\vbastidas"));
+				var accountCredentials = new LDAPHelper.DTO.LDAPDomainAccountCredential("BITAIVA", "victor.bastidas", requestAccountPassword("BITAIVA\\victor.bastidas"));
 
 				LogInfo($"{nameof(client.AuthenticateAsync)}...");
 				var httpResponse = await client.AuthenticateAsync(accountCredentials, RequestLabel, WebApiRequiresAccessToken);

--- a/client/LDAPWebApi.Client/Bitai.LDAPWebApi.Clients.csproj
+++ b/client/LDAPWebApi.Client/Bitai.LDAPWebApi.Clients.csproj
@@ -3,15 +3,15 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Bitai.LDAPWebApi.Clients</RootNamespace>
-    <Version>8.0.2</Version>
+    <Version>8.6.0</Version>
     <Authors>Viko Bastidas (BITAI)</Authors>
     <Company>BITAI</Company>
     <Product>LDAP Web API</Product>
     <Description>Library to make client requests to Bitai LDAP Web API.</Description>
-    <Copyright>© 2024 Bitai LDAPWebApi Clients. All rights reserved.</Copyright>
+    <Copyright>© 2026 Bitai LDAPWebApi Clients. All rights reserved.</Copyright>
     <PackageIcon>api1_64.png</PackageIcon>
-    <AssemblyVersion>8.0.2.7</AssemblyVersion>
-    <FileVersion>8.0.2.7</FileVersion>
+    <AssemblyVersion>8.6.0</AssemblyVersion>
+    <FileVersion>8.6.0</FileVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageProjectUrl>https://github.com/bitai-cs/LDAPWebApi</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bitai-cs/LDAPWebApi</RepositoryUrl>
@@ -24,7 +24,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>Upgraded to .NET 8</PackageReleaseNotes>
+    <PackageReleaseNotes>.NET 8 ready</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 
@@ -34,9 +34,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bitai.LDAPHelper.DTO" Version="8.0.0" />
-    <PackageReference Include="Bitai.WebApi.Helpers" Version="8.0.1" />
-    <PackageReference Include="Duende.IdentityModel" Version="7.0.0" />
+    <PackageReference Include="Bitai.LDAPHelper.DTO" Version="8.6.0" />
+    <PackageReference Include="Bitai.WebApi.Helpers" Version="8.0.2" />
+    <PackageReference Include="Duende.IdentityModel" Version="7.1.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
   </ItemGroup>
 

--- a/client/LDAPWebApi.Client/LDAPAuthenticationsWebApiClient.cs
+++ b/client/LDAPWebApi.Client/LDAPAuthenticationsWebApiClient.cs
@@ -1,8 +1,5 @@
-﻿using Bitai.WebApi.Client;
-using System.Net.Http;
+using Bitai.WebApi.Client;
 using System.Net.Http.Formatting;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Bitai.LDAPWebApi.Clients
 {
@@ -22,6 +19,14 @@ namespace Bitai.LDAPWebApi.Clients
 		{
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LDAPAuthenticationsWebApiClient"/> class with a custom HttpClientHandler.
+		/// </summary>
+		/// <param name="ldapWebApiBaseUrl">LDAP Web Api base URL.</param>
+		/// <param name="ldapServerProfile">LDAP Server Profile Id.</param>
+		/// <param name="useLdapServerGlobalCatalog">Whether or not the global catalog of the LDAP server will be used; otherwise the local catalog of the LDAP server will be used.</param>
+		/// <param name="handler">The custom HttpClientHandler to handle HTTP requests.</param>
+		/// <param name="disposeHandler">true if the inner handler should be disposed of by Dispose(), false if you intend to reuse the inner handler.</param>
 		public LDAPAuthenticationsWebApiClient(string ldapWebApiBaseUrl, string ldapServerProfile, bool useLdapServerGlobalCatalog, HttpClientHandler handler, bool disposeHandler) : base(ldapWebApiBaseUrl, ldapServerProfile, useLdapServerGlobalCatalog, handler, disposeHandler)
 		{
 		}
@@ -37,6 +42,15 @@ namespace Bitai.LDAPWebApi.Clients
 		{
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LDAPAuthenticationsWebApiClient"/> class with Identity Server credentials and a custom HttpClientHandler.
+		/// </summary>
+		/// <param name="ldapWebApiBaseUrl">LDAP Web Api base URL.</param>
+		/// <param name="ldapServerProfile">LDAP Server Profile Id.</param>
+		/// <param name="useLdapServerGlobalCatalog">Whether or not the global catalog of the LDAP server will be used; otherwise the local catalog of the LDAP server will be used.</param>
+		/// <param name="clientCredential">Client credentials to request an access token from the Identity Server. This access token will be sent in the HTTP authorization header as Bearer Token.</param>
+		/// <param name="handler">The custom HttpClientHandler to handle HTTP requests.</param>
+		/// <param name="disposeHandler">true if the inner handler should be disposed of by Dispose(), false if you intend to reuse the inner handler.</param>
 		public LDAPAuthenticationsWebApiClient(string ldapWebApiBaseUrl, string ldapServerProfile, bool useLdapServerGlobalCatalog, WebApiClientCredential clientCredential, HttpClientHandler handler, bool disposeHandler) : base(ldapWebApiBaseUrl, ldapServerProfile, useLdapServerGlobalCatalog, clientCredential, handler, disposeHandler)
 		{
 		}

--- a/client/LDAPWebApi.Client/LDAPCatalogTypesWebApiClient.cs
+++ b/client/LDAPWebApi.Client/LDAPCatalogTypesWebApiClient.cs
@@ -1,8 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Bitai.WebApi.Client;
 
 namespace Bitai.LDAPWebApi.Clients
@@ -20,6 +15,12 @@ namespace Bitai.LDAPWebApi.Clients
 		{
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LDAPCatalogTypesWebApiClient"/> class with a custom HttpClientHandler.
+		/// </summary>
+		/// <param name="ldapWebApiBaseUrl">LDAP Web Api base URL.</param>
+		/// <param name="handler">The custom HttpClientHandler to handle HTTP requests.</param>
+		/// <param name="disposeHandler">true if the inner handler should be disposed of by Dispose(), false if you intend to reuse the inner handler.</param>
 		public LDAPCatalogTypesWebApiClient(string ldapWebApiBaseUrl, HttpClientHandler handler, bool disposeHandler) : base(ldapWebApiBaseUrl, handler, disposeHandler)
 		{
 		}
@@ -33,6 +34,13 @@ namespace Bitai.LDAPWebApi.Clients
 		{
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LDAPCatalogTypesWebApiClient"/> class with Identity Server credentials and a custom HttpClientHandler.
+		/// </summary>
+		/// <param name="ldapWebApiBaseUrl">LDAP Web Api base URL.</param>
+		/// <param name="clientCredentials">Client credentials to request an access token from the Identity Server. This access token will be sent in the HTTP authorization header as Bearer Token.</param>
+		/// <param name="handler">The custom HttpClientHandler to handle HTTP requests.</param>
+		/// <param name="disposeHandler">true if the inner handler should be disposed of by Dispose(), false if you intend to reuse the inner handler.</param>
 		public LDAPCatalogTypesWebApiClient(string ldapWebApiBaseUrl, WebApiClientCredential clientCredentials, HttpClientHandler handler, bool disposeHandler) : base(ldapWebApiBaseUrl, clientCredentials, handler, disposeHandler)
 		{
 		}

--- a/client/LDAPWebApi.Client/LDAPDirectoryWebApiClient.cs
+++ b/client/LDAPWebApi.Client/LDAPDirectoryWebApiClient.cs
@@ -1,7 +1,6 @@
-﻿using Bitai.LDAPHelper.DTO;
+using Bitai.LDAPHelper.DTO;
 using Bitai.LDAPWebApi.DTO;
 using Bitai.WebApi.Client;
-using System.Net.Http.Formatting;
 
 namespace Bitai.LDAPWebApi.Clients
 {
@@ -10,10 +9,24 @@ namespace Bitai.LDAPWebApi.Clients
 	/// </summary>
 	public class LDAPDirectoryWebApiClient : LDAPWebApiBaseClient
 	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LDAPDirectoryWebApiClient"/> class.
+		/// </summary>
+		/// <param name="ldapWebApiBaseUrl">LDAP Web Api base URL.</param>
+		/// <param name="ldapServerProfile">LDAP Server Profile Id.</param>
+		/// <param name="useLdapServerGlobalCatalog">Whether or not the global catalog of the LDAP server will be used; otherwise the local catalog of the LDAP server will be used.</param>
 		public LDAPDirectoryWebApiClient(string ldapWebApiBaseUrl, string ldapServerProfile, bool useLdapServerGlobalCatalog) : base(ldapWebApiBaseUrl, ldapServerProfile, useLdapServerGlobalCatalog)
 		{
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LDAPDirectoryWebApiClient"/> class with a custom HttpClientHandler.
+		/// </summary>
+		/// <param name="ldapWebApiBaseUrl">LDAP Web Api base URL.</param>
+		/// <param name="ldapServerProfile">LDAP Server Profile Id.</param>
+		/// <param name="useLdapServerGlobalCatalog">Whether or not the global catalog of the LDAP server will be used; otherwise the local catalog of the LDAP server will be used.</param>
+		/// <param name="handler">The custom HttpClientHandler to handle HTTP requests.</param>
+		/// <param name="disposeHandler">true if the inner handler should be disposed of by Dispose(), false if you intend to reuse the inner handler.</param>
 		public LDAPDirectoryWebApiClient(string ldapWebApiBaseUrl, string ldapServerProfile, bool useLdapServerGlobalCatalog, HttpClientHandler handler, bool disposeHandler) : base(ldapWebApiBaseUrl, ldapServerProfile, useLdapServerGlobalCatalog, handler, disposeHandler)
 		{
 		}
@@ -29,6 +42,15 @@ namespace Bitai.LDAPWebApi.Clients
 		{
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LDAPDirectoryWebApiClient"/> class with Identity Server credentials and a custom HttpClientHandler.
+		/// </summary>
+		/// <param name="ldapWebApiBaseUrl">LDAP Web Api base URL.</param>
+		/// <param name="ldapServerProfile">LDAP Server Profile Id.</param>
+		/// <param name="useLdapServerGlobalCatalog">Whether or not the global catalog of the LDAP server will be used; otherwise the local catalog of the LDAP server will be used.</param>
+		/// <param name="clientCredentials">Client credentials to request an access token from the Identity Server. This access token will be sent in the HTTP authorization header as Bearer Token.</param>
+		/// <param name="handler">The custom HttpClientHandler to handle HTTP requests.</param>
+		/// <param name="disposeHandler">true if the inner handler should be disposed of by Dispose(), false if you intend to reuse the inner handler.</param>
 		public LDAPDirectoryWebApiClient(string ldapWebApiBaseUrl, string ldapServerProfile, bool useLdapServerGlobalCatalog, WebApiClientCredential clientCredentials, HttpClientHandler handler, bool disposeHandler) : base(ldapWebApiBaseUrl, ldapServerProfile, useLdapServerGlobalCatalog, clientCredentials, handler, disposeHandler)
 		{
 		}

--- a/client/LDAPWebApi.Client/LDAPGroupsDirectoryWebApiClient.cs
+++ b/client/LDAPWebApi.Client/LDAPGroupsDirectoryWebApiClient.cs
@@ -1,8 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Bitai.LDAPHelper.DTO;
 using Bitai.WebApi.Client;
 
@@ -13,10 +8,24 @@ namespace Bitai.LDAPWebApi.Clients
 	/// </summary>
 	public class LDAPGroupsDirectoryWebApiClient : LDAPWebApiBaseClient
 	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LDAPGroupsDirectoryWebApiClient"/> class.
+		/// </summary>
+		/// <param name="ldapWebApiBaseUrl">LDAP Web Api base URL.</param>
+		/// <param name="ldapServerProfile">LDAP Server Profile Id.</param>
+		/// <param name="useLdapServerGlobalCatalog">Whether or not the global catalog of the LDAP server will be used; otherwise the local catalog of the LDAP server will be used.</param>
 		public LDAPGroupsDirectoryWebApiClient(string ldapWebApiBaseUrl, string ldapServerProfile, bool useLdapServerGlobalCatalog) : base(ldapWebApiBaseUrl, ldapServerProfile, useLdapServerGlobalCatalog)
 		{
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LDAPGroupsDirectoryWebApiClient"/> class with a custom HttpClientHandler.
+		/// </summary>
+		/// <param name="ldapWebApiBaseUrl">LDAP Web Api base URL.</param>
+		/// <param name="ldapServerProfile">LDAP Server Profile Id.</param>
+		/// <param name="useLdapServerGlobalCatalog">Whether or not the global catalog of the LDAP server will be used; otherwise the local catalog of the LDAP server will be used.</param>
+		/// <param name="handler">The custom HttpClientHandler to handle HTTP requests.</param>
+		/// <param name="disposeHandler">true if the inner handler should be disposed of by Dispose(), false if you intend to reuse the inner handler.</param>
 		public LDAPGroupsDirectoryWebApiClient(string ldapWebApiBaseUrl, string ldapServerProfile, bool useLdapServerGlobalCatalog, HttpClientHandler handler, bool disposeHandler) : base(ldapWebApiBaseUrl, ldapServerProfile, useLdapServerGlobalCatalog, handler, disposeHandler)
 		{
 		}
@@ -32,6 +41,15 @@ namespace Bitai.LDAPWebApi.Clients
 		{
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LDAPGroupsDirectoryWebApiClient"/> class with Identity Server credentials and a custom HttpClientHandler.
+		/// </summary>
+		/// <param name="ldapWebApiBaseUrl">LDAP Web Api base URL.</param>
+		/// <param name="ldapServerProfile">LDAP Server Profile Id.</param>
+		/// <param name="useLdapServerGlobalCatalog">Whether or not the global catalog of the LDAP server will be used; otherwise the local catalog of the LDAP server will be used.</param>
+		/// <param name="clientCredentials">Client credentials to request an access token from the Identity Server. This access token will be sent in the HTTP authorization header as Bearer Token.</param>
+		/// <param name="handler">The custom HttpClientHandler to handle HTTP requests.</param>
+		/// <param name="disposeHandler">true if the inner handler should be disposed of by Dispose(), false if you intend to reuse the inner handler.</param>
 		public LDAPGroupsDirectoryWebApiClient(string ldapWebApiBaseUrl, string ldapServerProfile, bool useLdapServerGlobalCatalog, WebApiClientCredential clientCredentials, HttpClientHandler handler, bool disposeHandler) : base(ldapWebApiBaseUrl, ldapServerProfile, useLdapServerGlobalCatalog, clientCredentials, handler, disposeHandler)
 		{
 		}

--- a/client/LDAPWebApi.Client/LDAPServerProfilesWebApiClient.cs
+++ b/client/LDAPWebApi.Client/LDAPServerProfilesWebApiClient.cs
@@ -1,8 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Bitai.WebApi.Client;
 
 namespace Bitai.LDAPWebApi.Clients
@@ -12,10 +7,20 @@ namespace Bitai.LDAPWebApi.Clients
 	/// </summary>
 	public class LDAPServerProfilesWebApiClient : LDAPWebApiBaseClient
 	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LDAPServerProfilesWebApiClient"/> class.
+		/// </summary>
+		/// <param name="ldapWebApiBaseUrl">LDAP Web Api base URL.</param>
 		public LDAPServerProfilesWebApiClient(string ldapWebApiBaseUrl) : base(ldapWebApiBaseUrl)
 		{
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LDAPServerProfilesWebApiClient"/> class with a custom HttpClientHandler.
+		/// </summary>
+		/// <param name="ldapWebApiBaseUrl">LDAP Web Api base URL.</param>
+		/// <param name="handler">The custom HttpClientHandler to handle HTTP requests.</param>
+		/// <param name="disposeHandler">true if the inner handler should be disposed of by Dispose(), false if you intend to reuse the inner handler.</param>
 		public LDAPServerProfilesWebApiClient(string ldapWebApiBaseUrl, HttpClientHandler handler, bool disposeHandler) : base(ldapWebApiBaseUrl, handler, disposeHandler)
 		{
 		}
@@ -29,6 +34,13 @@ namespace Bitai.LDAPWebApi.Clients
 		{
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LDAPServerProfilesWebApiClient"/> class with Identity Server credentials and a custom HttpClientHandler.
+		/// </summary>
+		/// <param name="ldapWebApiBaseUrl">LDAP Web Api base URL.</param>
+		/// <param name="clientCredentials">Client credentials to request an access token from the Identity Server. This access token will be sent in the HTTP authorization header as Bearer Token.</param>
+		/// <param name="handler">The custom HttpClientHandler to handle HTTP requests.</param>
+		/// <param name="disposeHandler">true if the inner handler should be disposed of by Dispose(), false if you intend to reuse the inner handler.</param>
 		public LDAPServerProfilesWebApiClient(string ldapWebApiBaseUrl, WebApiClientCredential clientCredentials, HttpClientHandler handler, bool disposeHandler) : base(ldapWebApiBaseUrl, clientCredentials, handler, disposeHandler)
 		{
 		}

--- a/client/LDAPWebApi.Client/LDAPUserDirectoryWebApiClient.cs
+++ b/client/LDAPWebApi.Client/LDAPUserDirectoryWebApiClient.cs
@@ -1,17 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Net;
 using System.Net.Http.Formatting;
-using System.Reflection.Metadata.Ecma335;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Bitai.LDAPHelper.DTO;
 using Bitai.LDAPWebApi.DTO;
 using Bitai.WebApi.Client;
-using IdentityModel.Client;
-using Microsoft.VisualBasic;
 
 namespace Bitai.LDAPWebApi.Clients
 {
@@ -20,10 +10,24 @@ namespace Bitai.LDAPWebApi.Clients
 	/// </summary>
 	public class LDAPUserDirectoryWebApiClient : LDAPWebApiBaseClient
 	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LDAPUserDirectoryWebApiClient"/> class.
+		/// </summary>
+		/// <param name="webApiBaseUrl">LDAP Web Api base URL.</param>
+		/// <param name="serverProfile">LDAP Server Profile Id.</param>
+		/// <param name="useGlobalCatalog">Whether or not the global catalog of the LDAP server will be used; otherwise the local catalog of the LDAP server will be used.</param>
 		public LDAPUserDirectoryWebApiClient(string webApiBaseUrl, string serverProfile, bool useGlobalCatalog) : base(webApiBaseUrl, serverProfile, useGlobalCatalog)
 		{
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LDAPUserDirectoryWebApiClient"/> class with a custom HttpClientHandler.
+		/// </summary>
+		/// <param name="webApiBaseUrl">LDAP Web Api base URL.</param>
+		/// <param name="serverProfile">LDAP Server Profile Id.</param>
+		/// <param name="useGlobalCatalog">Whether or not the global catalog of the LDAP server will be used; otherwise the local catalog of the LDAP server will be used.</param>
+		/// <param name="handler">The custom HttpClientHandler to handle HTTP requests.</param>
+		/// <param name="disposeHandle">true if the inner handler should be disposed of by Dispose(), false if you intend to reuse the inner handler.</param>
 		public LDAPUserDirectoryWebApiClient(string webApiBaseUrl, string serverProfile, bool useGlobalCatalog, HttpClientHandler handler, bool disposeHandle) : base(webApiBaseUrl, serverProfile, useGlobalCatalog, handler, disposeHandle)
 		{
 		}
@@ -39,6 +43,15 @@ namespace Bitai.LDAPWebApi.Clients
 		{
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LDAPUserDirectoryWebApiClient"/> class with Identity Server credentials and a custom HttpClientHandler.
+		/// </summary>
+		/// <param name="webApiBaseUrl">LDAP Web Api base URL.</param>
+		/// <param name="serverProfile">LDAP Server Profile Id.</param>
+		/// <param name="useGlobalCatalog">Whether or not the global catalog of the LDAP server will be used; otherwise the local catalog of the LDAP server will be used.</param>
+		/// <param name="clientCredential">Client credentials to request an access token from the Identity Server. This access token will be sent in the HTTP authorization header as Bearer Token.</param>
+		/// <param name="handler">The custom HttpClientHandler to handle HTTP requests.</param>
+		/// <param name="disposeHandler">true if the inner handler should be disposed of by Dispose(), false if you intend to reuse the inner handler.</param>
 		public LDAPUserDirectoryWebApiClient(string webApiBaseUrl, string serverProfile, bool useGlobalCatalog, WebApiClientCredential clientCredential, HttpClientHandler handler, bool disposeHandler) : base(webApiBaseUrl, serverProfile, useGlobalCatalog, clientCredential, handler, disposeHandler)
 		{
 		}
@@ -47,21 +60,53 @@ namespace Bitai.LDAPWebApi.Clients
 
 
 		#region GET /api/{serverProfile}/{catalogType}/Directory/Users/filterBy
+		/// <summary>
+		/// Search for user accounts using the sAMAccountName attribute.
+		/// </summary>
+		/// <param name="samAccountName">The sAMAccountName value to filter by.</param>
+		/// <param name="setBearerToken">Whether or not to add the security "Bearer Token" to the HTTP request header.</param>
+		/// <param name="requestLabel">Custom tag to identify the request and mark the data returned in the response.</param>
+		/// <returns>An <see cref="IHttpResponse{TContent}"/> that encapsulates an <see cref="IHttpResponse"/>.</returns>
 		public Task<IHttpResponse> SearchFilteringByAsync(string samAccountName, bool setBearerToken = true, string? requestLabel = default)
 		{
 			return SearchFilteringByAsync(null, samAccountName, null, null, null, null, requestLabel, setBearerToken, default);
 		}
 
+		/// <summary>
+		/// Search for user accounts using the sAMAccountName attribute and specifying the required attributes.
+		/// </summary>
+		/// <param name="samAccountName">The sAMAccountName value to filter by.</param>
+		/// <param name="requiredAttributes">Set of LDAP attributes that the search result should contain.</param>
+		/// <param name="setBearerToken">Whether or not to add the security "Bearer Token" to the HTTP request header.</param>
+		/// <param name="requestLabel">Custom tag to identify the request and mark the data returned in the response.</param>
+		/// <returns>An <see cref="IHttpResponse{TContent}"/> that encapsulates an <see cref="IHttpResponse"/>.</returns>
 		public Task<IHttpResponse> SearchFilteringByAsync(string samAccountName, RequiredEntryAttributes requiredAttributes, bool setBearerToken = true, string? requestLabel = default)
 		{
 			return SearchFilteringByAsync(null, samAccountName, null, null, null, requiredAttributes, requestLabel, setBearerToken, default);
 		}
 
+		/// <summary>
+		/// Search for user accounts using a specific LDAP attribute filter.
+		/// </summary>
+		/// <param name="filterAttribute">LDAP attribute type to filter by.</param>
+		/// <param name="filterValue">Value that will be used to filter the LDAP attribute assigned in the filterAttribute parameter.</param>
+		/// <param name="setBearerToken">Whether or not to add the security "Bearer Token" to the HTTP request header.</param>
+		/// <param name="requestLabel">Custom tag to identify the request and mark the data returned in the response.</param>
+		/// <returns>An <see cref="IHttpResponse{TContent}"/> that encapsulates an <see cref="IHttpResponse"/>.</returns>
 		public Task<IHttpResponse> SearchFilteringByAsync(EntryAttribute filterAttribute, string filterValue, bool setBearerToken = true, string? requestLabel = default)
 		{
 			return SearchFilteringByAsync(filterAttribute, filterValue, null, null, null, null, requestLabel, setBearerToken, default);
 		}
 
+		/// <summary>
+		/// Search for user accounts using a specific LDAP attribute filter and specifying the required attributes.
+		/// </summary>
+		/// <param name="filterAttribute">LDAP attribute type to filter by.</param>
+		/// <param name="filterValue">Value that will be used to filter the LDAP attribute assigned in the filterAttribute parameter.</param>
+		/// <param name="requiredAttributes">Set of LDAP attributes that the search result should contain.</param>
+		/// <param name="setBearerToken">Whether or not to add the security "Bearer Token" to the HTTP request header.</param>
+		/// <param name="requestLabel">Custom tag to identify the request and mark the data returned in the response.</param>
+		/// <returns>An <see cref="IHttpResponse{TContent}"/> that encapsulates an <see cref="IHttpResponse"/>.</returns>
 		public Task<IHttpResponse> SearchFilteringByAsync(EntryAttribute filterAttribute, string filterValue, RequiredEntryAttributes requiredAttributes, bool setBearerToken = true, string? requestLabel = default)
 		{
 			return SearchFilteringByAsync(filterAttribute, filterValue, null, null, null, requiredAttributes, requestLabel, setBearerToken, default);

--- a/client/LDAPWebApi.Client/LDAPWebApiBaseClient.cs
+++ b/client/LDAPWebApi.Client/LDAPWebApiBaseClient.cs
@@ -1,4 +1,4 @@
-﻿using Bitai.LDAPHelper.DTO;
+using Bitai.LDAPHelper.DTO;
 using Bitai.LDAPWebApi.DTO;
 using Bitai.WebApi.Client;
 
@@ -31,18 +31,40 @@ namespace Bitai.LDAPWebApi.Clients
 
 
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LDAPWebApiBaseClient"/> class.
+		/// </summary>
+		/// <param name="ldapWebApiBaseUrl">LDAP Web Api base URL.</param>
 		protected LDAPWebApiBaseClient(string ldapWebApiBaseUrl) : base(ldapWebApiBaseUrl)
 		{
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LDAPWebApiBaseClient"/> class with a custom HttpClientHandler.
+		/// </summary>
+		/// <param name="ldapWebApiBaseUrl">LDAP Web Api base URL.</param>
+		/// <param name="handler">The custom HttpClientHandler to handle HTTP requests.</param>
+		/// <param name="disposeHandler">true if the inner handler should be disposed of by Dispose(), false if you intend to reuse the inner handler.</param>
 		protected LDAPWebApiBaseClient(string ldapWebApiBaseUrl, HttpClientHandler handler, bool disposeHandler) : base(ldapWebApiBaseUrl, handler, disposeHandler)
 		{
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LDAPWebApiBaseClient"/> class with Identity Server credentials.
+		/// </summary>
+		/// <param name="ldapWebApiBaseUrl">LDAP Web Api base URL.</param>
+		/// <param name="clientCredentials">Client credentials to request an access token from the Identity Server.</param>
 		protected LDAPWebApiBaseClient(string ldapWebApiBaseUrl, WebApiClientCredential clientCredentials) : base(ldapWebApiBaseUrl, clientCredentials)
 		{
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LDAPWebApiBaseClient"/> class with Identity Server credentials and a custom HttpClientHandler.
+		/// </summary>
+		/// <param name="ldapWebApiBaseUrl">LDAP Web Api base URL.</param>
+		/// <param name="clientCredentials">Client credentials to request an access token from the Identity Server.</param>
+		/// <param name="handler">The custom HttpClientHandler to handle HTTP requests.</param>
+		/// <param name="disposeHandler">true if the inner handler should be disposed of by Dispose(), false if you intend to reuse the inner handler.</param>
 		protected LDAPWebApiBaseClient(string ldapWebApiBaseUrl, WebApiClientCredential clientCredentials, HttpClientHandler handler, bool disposeHandler) : base(ldapWebApiBaseUrl, clientCredentials, handler, disposeHandler)
 		{
 		}
@@ -72,12 +94,29 @@ namespace Bitai.LDAPWebApi.Clients
 			UseLDAPServerGlobalCatalog = useLdapServerGlobalCatalog;
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LDAPWebApiBaseClient"/> class with server configuration details and a custom HttpClientHandler.
+		/// </summary>
+		/// <param name="ldapWebApiBaseUrl">LDAP Web Api base URL.</param>
+		/// <param name="ldapServerProfile">LDAP Server Profile Id.</param>
+		/// <param name="useLdapServerGlobalCatalog">Whether or not the global catalog of the LDAP server will be used; otherwise the local catalog of the LDAP server will be used.</param>
+		/// <param name="handler">The custom HttpClientHandler to handle HTTP requests.</param>
+		/// <param name="disposeHandler">true if the inner handler should be disposed of by Dispose(), false if you intend to reuse the inner handler.</param>
 		protected LDAPWebApiBaseClient(string ldapWebApiBaseUrl, string ldapServerProfile, bool useLdapServerGlobalCatalog, HttpClientHandler handler, bool disposeHandler) : base(ldapWebApiBaseUrl, handler, disposeHandler)
 		{
 			LDAPServerProfile = ldapServerProfile;
 			UseLDAPServerGlobalCatalog = useLdapServerGlobalCatalog;
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LDAPWebApiBaseClient"/> class with server configuration details, Identity Server credentials, and a custom HttpClientHandler.
+		/// </summary>
+		/// <param name="ldapWebApiBaseUrl">LDAP Web Api base URL.</param>
+		/// <param name="ldapServerProfile">LDAP Server Profile Id.</param>
+		/// <param name="useLdapServerGlobalCatalog">Whether or not the global catalog of the LDAP server will be used; otherwise the local catalog of the LDAP server will be used.</param>
+		/// <param name="clientCredentials">Client credentials to request an access token from the Identity Server.</param>
+		/// <param name="handler">The custom HttpClientHandler to handle HTTP requests.</param>
+		/// <param name="disposeHandler">true if the inner handler should be disposed of by Dispose(), false if you intend to reuse the inner handler.</param>
 		protected LDAPWebApiBaseClient(string ldapWebApiBaseUrl, string ldapServerProfile, bool useLdapServerGlobalCatalog, WebApiClientCredential clientCredentials, HttpClientHandler handler, bool disposeHandler) : base(ldapWebApiBaseUrl, clientCredentials, handler, disposeHandler)
 		{
 			LDAPServerProfile = ldapServerProfile;

--- a/client/LDAPWebApi.Client/README.md
+++ b/client/LDAPWebApi.Client/README.md
@@ -1,18 +1,140 @@
-﻿# Bitai.LDAPWebApi.Client
+# Bitai.LDAPWebApi.Clients
 
-Bitai.LDAPWebApi.Client is a helper library designed to facilitate making requests to the Bitai.LDAPWebApi. This library provides client helper classes that simplify the interaction with the LDAP Web API, allowing you to easily integrate LDAP functionality into your applications.
+[![NuGet Version](https://img.shields.io/nuget/v/Bitai.LDAPWebApi.Clients.svg?style=flat-sign)](https://www.nuget.org/packages/Bitai.LDAPWebApi.Clients/)
+[![.NET Core](https://img.shields.io/badge/.NET-8.0%20%7C%20Standard%202.0-blue.svg)](https://dotnet.microsoft.com)
+[![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20Linux%20%7C%20macOS-lightgrey.svg)]()
 
-## Features
+`Bitai.LDAPWebApi.Client` is a strongly-typed .NET client library designed to streamline integration with the **Bitai.LDAPWebApi** service. It eliminates boilerplate HTTP code by providing highly specialized, fluent client handlers for authentication, directory lookups, Active Directory administration, and profile management.
 
-- **Easy API Requests**: Simplified methods for making GET, POST, PUT, and DELETE requests.
-- **Authentication**: Built-in support for handling API authentication.
-- **Response Handling**: Utilities for parsing and handling API responses.
-- **Error Management**: Consistent error handling and logging mechanisms.
-- **Configuration**: Flexible configuration options for API endpoints and settings.
+---
 
-## Installation
+## 🌟 Key Architecture & Public Clients
 
-You can install Bitai.LDAPWebApi.Client via NuGet Package Manager:
+The library is organized into specialized client classes, each mapping directly to an LDAP Web API controller. All clients leverage a common base logic for request generation, authorization headers, and custom network configurations.
 
-```sh
+### 1. `LDAPWebApiBaseClient`
+The abstract base class for all Web API clients in the ecosystem. It inherits from `WebApiBaseClient` and manages the core connection details.
+*   **Key Responsibilities**:
+    *   Exposes global routing configurations like `LDAPServerProfile` and `UseLDAPServerGlobalCatalog`.
+    *   Provides inner URL formatting helpers (`GetOptionalEntryAttributeName`, `GetOptionalRequiredEntryAttributesName`, `GetOptionalBooleanValue`).
+    *   Defines static controller routing tokens inside the `ControllerNames` nested class.
+
+### 2. `LDAPAuthenticationsWebApiClient`
+Dedicated to performing authentication operations against the directory services.
+*   **Core Method**:
+    *   `AuthenticateAsync(LDAPDomainAccountCredential credential, ...)`: Submits domain credentials to the LDAP API to validate user authenticity, returning a detailed `LDAPDomainAccountAuthenticationResult` containing error context on failures.
+
+### 3. `LDAPDirectoryWebApiClient`
+Provides generic read-only entry search functionalities across the LDAP directory.
+*   **Core Methods**:
+    *   `SearchByIdentifierAsync(...)`: Resolves any LDAP entry matching a specific unique identifier (such as distinguishedName, mail, etc.), filtering properties to optimize performance.
+    *   `SearchByFiltersAsync(...)`: Performs logical conditional queries mapping up to two query attributes (e.g., mail, cn, company) to filter entries.
+
+### 4. `LDAPGroupsDirectoryWebApiClient`
+Specialized client focused exclusively on group queries.
+*   **Core Methods**:
+    *   `SearchByIdentifierAsync(...)`: Fetches information about a specific group matching an identifier.
+    *   `SearchFilteringByAsync(...)`: Queries multiple groups using configurable directory attribute filters.
+
+### 5. `LDAPUserDirectoryWebApiClient`
+The most comprehensive client in the library, handling advanced user searches and full Microsoft Active Directory user provisioning.
+*   **Core Methods**:
+    *   `SearchFilteringByAsync(...)`: Provides multiple overloads to query user accounts (by sAMAccountName or other attributes).
+    *   `CreateMsADUserAccountAsync(LDAPMsADUserAccount account, ...)`: Provisions a new MS Active Directory user account.
+    *   `SetMsADUserAccountPasswordAsync(LDAPCredential credential, ...)`: Firmly updates or resets user passwords inside AD securely.
+    *   `DisableMsADUserAccountAsync(string identifier, ...)`: Toggles active directory flags to disable a user account.
+    *   `RemoveMsADUserAccountAsync(string identifier, ...)`: Safely deletes a user account from AD.
+
+### 6. `LDAPCatalogTypesWebApiClient`
+Retrieves the types of catalogs supported by the LDAP service.
+*   **Core Method**:
+    *   `GetAllAsync(...)`: Queries all catalog types (Global vs Local) registered on the LDAP Web API.
+
+### 7. `LDAPServerProfilesWebApiClient`
+Exposes management configurations for configured LDAP servers.
+*   **Core Methods**:
+    *   `GetProfileIdsAsync(...)`: Retrieves the unique IDs of all configured LDAP server profiles.
+    *   `GetByProfileIdAsync(string profileId, ...)`: Fetches full structural details of a specific server profile.
+    *   `GetAllAsync(...)`: Retrieves all profiles registered in the system.
+
+---
+
+## 🚀 Installation
+
+Install the library via the NuGet Package Manager Console:
+
+```bash
 dotnet add package Bitai.LDAPWebApi.Client
+```
+
+---
+
+## 💻 Integrated Code Example
+
+The following code illustrates how to configure the `LDAPUserDirectoryWebApiClient` with Identity Server credentials and execute a secure user query:
+
+```csharp
+using System;
+using System.Threading.Tasks;
+using Bitai.LDAPHelper.DTO;
+using Bitai.LDAPWebApi.Clients;
+using Bitai.WebApi.Client;
+
+public class LDAPService
+{
+    private readonly LDAPUserDirectoryWebApiClient _userClient;
+
+    public LDAPService()
+    {
+        // Define API base address and target LDAP Profile ID
+        string apiBaseUrl = "https://api.company.local/ldap";
+        string serverProfileId = "DefaultActiveDirectory";
+        bool useGlobalCatalog = false;
+
+        // Configure client credentials to automatically get Bearer Tokens
+        var credentials = new WebApiClientCredential
+        {
+            ClientId = "ldap-client-app",
+            ClientSecret = "SuperSecureClientSecret123!",
+            Authority = "https://identity.company.local",
+            Scope = "ldap.api.read ldap.api.write"
+        };
+
+        // Initialize the client
+        _userClient = new LDAPUserDirectoryWebApiClient(
+            apiBaseUrl, 
+            serverProfileId, 
+            useGlobalCatalog, 
+            credentials
+        );
+    }
+
+    public async Task FindUserByEmailAsync(string email)
+    {
+        // Execute search requesting specific attributes (minimizing payload size)
+        var response = await _userClient.SearchFilteringByAsync(
+            EntryAttribute.mail, 
+            email, 
+            RequiredEntryAttributes.Few, 
+            setBearerToken: true
+        );
+
+        if (response.IsSuccessStatusCode)
+        {
+            var searchResult = response.GetContent<LDAPSearchResult>();
+            Console.WriteLine($"Search completed. Matched {searchResult.Entries.Count} user(s).");
+            
+            foreach (var entry in searchResult.Entries)
+            {
+                Console.WriteLine($"Name: {entry.displayName} | DN: {entry.distinguishedName}");
+            }
+        }
+        else
+        {
+            Console.WriteLine($"Error querying API: {response.ReasonPhrase}");
+        }
+    }
+}
+```
+
+---

--- a/src/LDAPWebApi/Bitai.LDAPWebApi.csproj
+++ b/src/LDAPWebApi/Bitai.LDAPWebApi.csproj
@@ -5,13 +5,13 @@
 		<RootNamespace>Bitai.LDAPWebApi</RootNamespace>
 		<AssemblyName>Bitai.LDAPWebApi</AssemblyName>
 		<UserSecretsId>d895caed-ec5c-4dfe-b5f1-1d6df1609afe</UserSecretsId>
-		<Version>8.0.2</Version>
-		<AssemblyVersion>8.0.2.7</AssemblyVersion>
+		<Version>8.1.7</Version>
+		<AssemblyVersion>8.1.7.1</AssemblyVersion>
 		<Authors>Viko Bastidas (BITAI)</Authors>
 		<Company>BITAI</Company>
 		<Product>LDAP Web API</Product>
 		<Nullable>enable</Nullable>
-		<FileVersion>8.0.2.7</FileVersion>
+		<FileVersion>8.1.7.1</FileVersion>
 		<Description>Web API to access and query LDAP server.</Description>
 		<PackageProjectUrl>https://github.com/bitai-cs/LDAPWebApi</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/bitai-cs/LDAPWebApi</RepositoryUrl>
@@ -40,8 +40,8 @@
 	  <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
 	  <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
 	  <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
-	  <PackageReference Include="Bitai.LDAPHelper" Version="8.0.0" />
-	  <PackageReference Include="Bitai.WebApi.Helpers" Version="8.0.1" />
+	  <PackageReference Include="Bitai.LDAPHelper" Version="8.6.0" />
+	  <PackageReference Include="Bitai.WebApi.Helpers" Version="8.0.2" />
 	  <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.13" />
 	  <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
 	  <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />

--- a/src/LDAPWebApi/Controllers/ApiControllerBase.cs
+++ b/src/LDAPWebApi/Controllers/ApiControllerBase.cs
@@ -1,16 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using Bitai.LDAPHelper.DTO;
+using Bitai.LDAPHelper.LdapAdapters;
 using Bitai.LDAPHelper.QueryFilters;
-using Bitai.WebApi.Server;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
 namespace Bitai.LDAPWebApi.Controllers;
 
@@ -35,6 +27,11 @@ public abstract class ApiControllerBase<T> : ControllerBase
 	protected Configurations.LDAP.LDAPServerProfiles ServerProfiles { get; }
 
 	/// <summary>
+	/// LDAP connection factory adapter (Adapter Pattern).
+	/// </summary>
+	protected ILdapConnectionFactoryAdapter ConnectionFactory { get; }
+
+	/// <summary>
 	/// Route name for each LDAP Catalog.
 	/// </summary>
 	protected DTO.LDAPServerCatalogTypes CatalogTypeRoutes => new DTO.LDAPServerCatalogTypes();
@@ -48,11 +45,13 @@ public abstract class ApiControllerBase<T> : ControllerBase
 	/// <param name="configuration">Injected <see cref="IConfiguration"/></param>
 	/// <param name="logger">Logger</param>
 	/// <param name="serverProfiles">Injected <see cref="Configurations.LDAP.LDAPServerProfiles"/></param>
-	protected ApiControllerBase(IConfiguration configuration, ILogger<T> logger, Configurations.LDAP.LDAPServerProfiles serverProfiles)
+	/// <param name="connectionFactory">Injected <see cref="ILdapConnectionFactoryAdapter"/></param>
+	protected ApiControllerBase(IConfiguration configuration, ILogger<T> logger, Configurations.LDAP.LDAPServerProfiles serverProfiles, ILdapConnectionFactoryAdapter connectionFactory)
 	{
 		Configuration = configuration;
 		Logger = logger;
 		ServerProfiles = serverProfiles;
+		ConnectionFactory = connectionFactory;
 	}
 
 
@@ -104,7 +103,27 @@ public abstract class ApiControllerBase<T> : ControllerBase
 	/// <returns></returns>
 	protected LDAPHelper.Searcher GetLdapSearcher(LDAPHelper.ClientConfiguration clientConfiguration)
 	{
-		return new LDAPHelper.Searcher(clientConfiguration);
+		return new LDAPHelper.Searcher(clientConfiguration, ConnectionFactory);
+	}
+
+	/// <summary>
+	/// Get an instance of <see cref="LDAPHelper.AccountManager"/>
+	/// </summary>
+	/// <param name="clientConfiguration"><see cref="LDAPHelper.ClientConfiguration"/> to be used by <see cref="LDAPHelper.AccountManager"/></param>
+	/// <returns></returns>
+	protected LDAPHelper.AccountManager GetAccountManager(LDAPHelper.ClientConfiguration clientConfiguration)
+	{
+		return new LDAPHelper.AccountManager(clientConfiguration, ConnectionFactory);
+	}
+
+	/// <summary>
+	/// Get an instance of <see cref="LDAPHelper.Authenticator"/>
+	/// </summary>
+	/// <param name="connectionInfo"><see cref="LDAPHelper.ConnectionInfo"/> to be used by <see cref="LDAPHelper.Authenticator"/></param>
+	/// <returns></returns>
+	protected LDAPHelper.Authenticator GetAuthenticator(LDAPHelper.ConnectionInfo connectionInfo)
+	{
+		return new LDAPHelper.Authenticator(connectionInfo, ConnectionFactory);
 	}
 
 	/// <summary>

--- a/src/LDAPWebApi/Controllers/AuthRequirements/ApiScopeRequirementHandler.cs
+++ b/src/LDAPWebApi/Controllers/AuthRequirements/ApiScopeRequirementHandler.cs
@@ -1,13 +1,18 @@
 ﻿using Microsoft.AspNetCore.Authorization;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Bitai.LDAPWebApi.Controllers.AuthRequirements;
 
+/// <summary>
+/// Handles the authentication requirement for API scopes.
+/// </summary>
 public class ApiScopeRequirementHandler : AuthorizationHandler<ApiScopeRequirement>
 {
+    /// <summary>
+    /// Handles the authentication requirement for API scopes.
+    /// </summary>
+    /// <param name="context">The authorization context. See <see cref="AuthorizationHandlerContext"/>.</param>
+    /// <param name="requirement">The authentication requirement. See <see cref="ApiScopeRequirement"/>.</param>
+    /// <returns></returns>
     protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, ApiScopeRequirement requirement)
     {
         if (!context.User.HasClaim(c => c.Type == "scope" && c.Issuer == requirement.Issuer))

--- a/src/LDAPWebApi/Controllers/AuthenticationsController.cs
+++ b/src/LDAPWebApi/Controllers/AuthenticationsController.cs
@@ -1,17 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Bitai.LDAPHelper.DTO;
-using Bitai.LDAPHelper.QueryFilters;
+using Bitai.LDAPHelper.LdapAdapters;
 using Bitai.LDAPWebApi.Configurations.App;
-using Bitai.WebApi.Server;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
 namespace Bitai.LDAPWebApi.Controllers;
 
@@ -27,8 +18,9 @@ public class AuthenticationsController : ApiControllerBase<AuthenticationsContro
 	/// </summary>
 	/// <param name="configuration">Injected <see cref="IConfiguration"/></param>
 	/// <param name="logger">See <see cref="ILogger{TCategoryName}"/>.</param>
-	/// <param name="serverProfiles">Injected <see cref="Configurations.LDAP. LDAPServerProfiles"/></param>        
-	public AuthenticationsController(IConfiguration configuration, ILogger<AuthenticationsController> logger, Configurations.LDAP.LDAPServerProfiles serverProfiles) : base(configuration, logger, serverProfiles) { }
+	/// <param name="serverProfiles">Injected <see cref="Configurations.LDAP. LDAPServerProfiles"/></param>
+	/// <param name="connectionFactory">Injected <see cref="ILdapConnectionFactoryAdapter"/></param>
+	public AuthenticationsController(IConfiguration configuration, ILogger<AuthenticationsController> logger, Configurations.LDAP.LDAPServerProfiles serverProfiles, ILdapConnectionFactoryAdapter connectionFactory) : base(configuration, logger, serverProfiles, connectionFactory) { }
 
 
 
@@ -38,7 +30,7 @@ public class AuthenticationsController : ApiControllerBase<AuthenticationsContro
 	/// <param name="serverProfile">LDAP Server Profile Id that defines part of the path. See <see cref="Configurations.LDAP.LDAPServerProfile"/></param>
 	/// <param name="catalogType">Name of the LDAP catalog that defines part of the path. See <see cref="DTO.LDAPServerCatalogTypes"/></param>
 	/// <param name="credential">Account credential to validate. See <see cref="LDAPDomainAccountCredential"/></param>
-	/// <param name="requestLabel">Valor personalizado para etiquetar la respuesta. Can e null</param>
+	/// <param name="requestLabel">Label to tag the results. Optional, it can be null</param>
 	/// <returns><see cref="LDAPDomainAccountAuthenticationResult"/></returns>
 	[Authorize(WebApiScopesConfiguration.AuthorizationPolicyForAnyApiScopeName)]
 	[HttpPost]
@@ -56,7 +48,7 @@ public class AuthenticationsController : ApiControllerBase<AuthenticationsContro
 
 		var ldapClientConfig = GetLdapClientConfiguration(serverProfile.ToString(), IsGlobalCatalog(catalogType), out var ldapServerProfile);
 
-		var authenticator = new LDAPHelper.Authenticator(ldapClientConfig.ServerSettings);
+		var authenticator = GetAuthenticator(ldapClientConfig.ServerSettings);
 
 		if (string.IsNullOrEmpty(credential.DomainName))
 			credential.DomainName = ldapServerProfile.DefaultDomainName; 

--- a/src/LDAPWebApi/Controllers/CatalogTypesController.cs
+++ b/src/LDAPWebApi/Controllers/CatalogTypesController.cs
@@ -1,13 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using Bitai.LDAPHelper.LdapAdapters;
 using Bitai.LDAPWebApi.Configurations.App;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
 namespace Bitai.LDAPWebApi.Controllers;
 
@@ -17,13 +11,14 @@ namespace Bitai.LDAPWebApi.Controllers;
 [ApiController]
 public class CatalogTypesController : ApiControllerBase<CatalogTypesController>
 {
-	/// <summary>
-	/// Constructor
-	/// </summary>
-	/// <param name="configuration">Injected <see cref="IConfiguration"/></param>
-	/// <param name="logger">See <see cref="ILogger{TCategoryName}"/></param>
-	/// <param name="serverProfiles">Injected <see cref="Configurations.LDAP. LDAPServerProfiles"/></param>        
-	public CatalogTypesController(IConfiguration configuration, ILogger<CatalogTypesController> logger, Configurations.LDAP.LDAPServerProfiles serverProfiles) : base(configuration, logger, serverProfiles)
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="configuration">Injected <see cref="IConfiguration"/></param>
+    /// <param name="logger">See <see cref="ILogger{TCategoryName}"/></param>
+    /// <param name="serverProfiles">Injected <see cref="Configurations.LDAP. LDAPServerProfiles"/></param>
+    /// <param name="connectionFactory">Injected <see cref="ILdapConnectionFactoryAdapter"/></param>
+    public CatalogTypesController(IConfiguration configuration, ILogger<CatalogTypesController> logger, Configurations.LDAP.LDAPServerProfiles serverProfiles, ILdapConnectionFactoryAdapter connectionFactory) : base(configuration, logger, serverProfiles, connectionFactory)
 	{
 	}
 

--- a/src/LDAPWebApi/Controllers/DirectoryController.cs
+++ b/src/LDAPWebApi/Controllers/DirectoryController.cs
@@ -1,22 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Threading.Tasks;
+using Bitai.LDAPHelper.LdapAdapters;
 using Bitai.LDAPHelper.DTO;
 using Bitai.LDAPHelper.QueryFilters;
 using Bitai.LDAPWebApi.Configurations.App;
 using Bitai.LDAPWebApi.DTO;
 using Bitai.WebApi.Server;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Filters;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
 namespace Bitai.LDAPWebApi.Controllers;
 
@@ -33,8 +22,9 @@ public class DirectoryController : ApiControllerBase<DirectoryController>
 	/// </summary>
 	/// <param name="configuration">Injected <see cref="IConfiguration"/></param>
 	/// <param name="logger">Logger</param>
-	/// <param name="serverProfiles">Injected <see cref="Configurations.LDAP.LDAPServerProfiles"/></param>        
-	public DirectoryController(IConfiguration configuration, ILogger<DirectoryController> logger, Configurations.LDAP.LDAPServerProfiles serverProfiles) : base(configuration, logger, serverProfiles)
+	/// <param name="serverProfiles">Injected <see cref="Configurations.LDAP.LDAPServerProfiles"/></param>
+	/// <param name="connectionFactory">Injected <see cref="ILdapConnectionFactoryAdapter"/></param>
+	public DirectoryController(IConfiguration configuration, ILogger<DirectoryController> logger, Configurations.LDAP.LDAPServerProfiles serverProfiles, ILdapConnectionFactoryAdapter connectionFactory) : base(configuration, logger, serverProfiles, connectionFactory)
 	{
 	}
 
@@ -185,7 +175,7 @@ public class DirectoryController : ApiControllerBase<DirectoryController>
 
 		var clientConfig = GetLdapClientConfiguration(serverProfile, IsGlobalCatalog(catalogType));
 
-		var accountManager = new LDAPHelper.AccountManager(clientConfig);
+		var accountManager = GetAccountManager(clientConfig);
 		accountManager.InitializeMissingMsADUserAccountDN(newUserAccount);
 
 		#region Check if DN already exists
@@ -193,7 +183,7 @@ public class DirectoryController : ApiControllerBase<DirectoryController>
 		var attributeFilter = new LDAPHelper.QueryFilters.AttributeFilter(EntryAttribute.distinguishedName, new LDAPHelper.QueryFilters.FilterValue(newUserAccount.DistinguishedName));
 		var searchFilterCombiner = new LDAPHelper.QueryFilters.AttributeFilterCombiner(false, true, new List<LDAPHelper.QueryFilters.ICombinableFilter> { onlyUsersFilterCombiner, attributeFilter });
 
-		var searcher = new LDAPHelper.Searcher(clientConfig);
+		var searcher = GetLdapSearcher(clientConfig);
 		var searchResult = await searcher.SearchEntriesAsync(searchFilterCombiner, RequiredEntryAttributes.Minimun, requestLabel);
 		if (!searchResult.IsSuccessfulOperation)
 		{
@@ -321,7 +311,7 @@ public class DirectoryController : ApiControllerBase<DirectoryController>
 		var entry = searchResult.Entries.Single();
 
 		var dnCredential = new LDAPDistinguishedNameCredential(entry.distinguishedName, credential.Password);
-		var accountManager = new LDAPHelper.AccountManager(GetLdapClientConfiguration(serverProfile, IsGlobalCatalog(catalogType)));
+		var accountManager = GetAccountManager(GetLdapClientConfiguration(serverProfile, IsGlobalCatalog(catalogType)));
 		var pwdUpdateResult = await accountManager.SetUserAccountPasswordForMsAD(dnCredential, requestLabel);
 
 		if (!pwdUpdateResult.IsSuccessfulOperation)
@@ -384,7 +374,7 @@ public class DirectoryController : ApiControllerBase<DirectoryController>
 				ThrowExceptionForUnsuccessfulOperation($"Failed to disable user account {identifier}.", searchResult);
 		}
 
-		var accountManager = new LDAPHelper.AccountManager(clientConfig);
+		var accountManager = GetAccountManager(clientConfig);
 
 		var disableResult = await accountManager.DisableUserAccountForMsAD(distinguishedName, requestLabel);
 		if (!disableResult.IsSuccessfulOperation)
@@ -437,7 +427,7 @@ public class DirectoryController : ApiControllerBase<DirectoryController>
 				ThrowExceptionForUnsuccessfulOperation($"Failed to disable user account {identifier}.", searchResult);
 		}
 
-		var accountManager = new LDAPHelper.AccountManager(clientConfig);
+		var accountManager = GetAccountManager(clientConfig);
 
 		var removeResult = await accountManager.RemoveUserAccountForMsAD(distinguishedName, requestLabel);
 

--- a/src/LDAPWebApi/Controllers/ServerProfilesController.cs
+++ b/src/LDAPWebApi/Controllers/ServerProfilesController.cs
@@ -1,13 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using Bitai.LDAPHelper.LdapAdapters;
 using Bitai.LDAPWebApi.Configurations.App;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
 namespace Bitai.LDAPWebApi.Controllers;
 
@@ -23,7 +17,9 @@ public class ServerProfilesController : ApiControllerBase<ServerProfilesControll
     /// <param name="configuration">See <see cref="Microsoft.Extensions.Configuration.IConfiguration"/></param>
     /// <param name="logger">See <see cref="ILogger{TCategoryName}"/></param>
     /// <param name="serverProfiles">Injected <see cref="Configurations.LDAP. LDAPServerProfiles"/></param>
-    public ServerProfilesController(IConfiguration configuration, ILogger<ServerProfilesController> logger, Configurations.LDAP.LDAPServerProfiles serverProfiles) : base(configuration, logger, serverProfiles)
+    /// <param name="connectionFactory">Injected <see cref="ILdapConnectionFactoryAdapter"/></param>
+    /// 
+    public ServerProfilesController(IConfiguration configuration, ILogger<ServerProfilesController> logger, Configurations.LDAP.LDAPServerProfiles serverProfiles, ILdapConnectionFactoryAdapter connectionFactory) : base(configuration, logger, serverProfiles, connectionFactory)
     {
     }
 

--- a/src/LDAPWebApi/Dockerfile
+++ b/src/LDAPWebApi/Dockerfile
@@ -1,22 +1,39 @@
-#See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
+# See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+# --- Runtime Stage ---
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
-EXPOSE 5101
-EXPOSE 5100
+EXPOSE 8080
+EXPOSE 8081
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+# --- Build Stage ---
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
+
+# Copy project files first to leverage Docker cache restore layer
 COPY ["src/LDAPWebApi/Bitai.LDAPWebApi.csproj", "src/LDAPWebApi/"]
+COPY ["src/LDAPWebApi.DTO/Bitai.LDAPWebApi.DTO.csproj", "src/LDAPWebApi.DTO/"]
+
+# Restore NuGet packages
 RUN dotnet restore "src/LDAPWebApi/Bitai.LDAPWebApi.csproj"
+
+# Copy the rest of the source code
 COPY . .
+
+# Build the project under Release configuration
 WORKDIR "/src/src/LDAPWebApi"
-RUN dotnet build "Bitai.LDAPWebApi.csproj" -c Debug --no-restore -o /app/build
+RUN dotnet build "Bitai.LDAPWebApi.csproj" -c Release --no-restore -o /app/build
 
+# --- Publish Stage ---
 FROM build AS publish
-RUN dotnet publish "Bitai.LDAPWebApi.csproj" -c Debug --no-restore -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "Bitai.LDAPWebApi.csproj" -c Release --no-restore -o /app/publish /p:UseAppHost=false
 
+# --- Final Production Stage ---
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+
+# Run under the secure built-in non-root user (Standard in .NET 8)
+USER app
+
 ENTRYPOINT ["dotnet", "Bitai.LDAPWebApi.dll"]

--- a/src/LDAPWebApi/Helpers/StartupHelper.cs
+++ b/src/LDAPWebApi/Helpers/StartupHelper.cs
@@ -1,4 +1,6 @@
-﻿using Bitai.LDAPWebApi.Configurations.App;
+﻿using Bitai.LDAPHelper.LdapAdapters;
+using Bitai.LDAPHelper.LdapAdapters.Novell;
+using Bitai.LDAPWebApi.Configurations.App;
 using Bitai.LDAPWebApi.Configurations.LDAP;
 using Bitai.LDAPWebApi.Configurations.Security;
 using Bitai.LDAPWebApi.Configurations.Swagger;
@@ -161,6 +163,15 @@ public static class StartupHelpers
 			config.ConstraintMap.Add("ldapSvrPf", typeof(Controllers.Constraints.LDAPServerProfileRouteConstraint));
 			config.ConstraintMap.Add("ldapCatType", typeof(Controllers.Constraints.LDAPCatalogTypeRouteConstraint));
 		});
+
+		return services;
+	}
+
+	internal static IServiceCollection RegisterNovellLdapConnectionFactory(this IServiceCollection services)
+	{
+		Log.Information("{method}", nameof(RegisterNovellLdapConnectionFactory));
+
+		services.AddSingleton<ILdapConnectionFactoryAdapter, NovellLdapConnectionFactoryAdapter>();
 
 		return services;
 	}

--- a/src/LDAPWebApi/Startup.cs
+++ b/src/LDAPWebApi/Startup.cs
@@ -1,3 +1,5 @@
+using Bitai.LDAPHelper.LdapAdapters;
+using Bitai.LDAPHelper.LdapAdapters.Novell;
 using Bitai.LDAPWebApi.Helpers;
 using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Builder;
@@ -74,6 +76,8 @@ public class Startup
 		services.AddAuthorityConfiguration(Configuration, out var authorityConfiguration);
 
 		services.RegisterRouteConstraints();
+
+		services.RegisterNovellLdapConnectionFactory();
 
 		services.AddControllers();
 


### PR DESCRIPTION
Update LDAPHelper references. & fix README.md files.

## Summary by Sourcery

Introduce LDAP connection factory abstraction and Novell LDAP implementation while updating documentation and Docker configuration for .NET 8.

Enhancements:
- Add injectable ILdapConnectionFactoryAdapter to centralize LDAP connection creation and use it across search, account, and authentication helpers.
- Extend LDAP Web API client classes with additional constructors supporting custom HttpClientHandlers and Identity Server credentials, and improve XML documentation for public APIs.
- Refine the demo client defaults and sample usage to better reflect current server profiles and authentication flows.
- Update Dockerfile to target .NET 8 SDK/runtime, use Release builds, and run as a non-root app user.
- Register a Novell-based LDAP connection factory adapter in Startup and wire it through controllers for LDAP operations.

Documentation:
- Rewrite root and client README files with detailed architecture overview, feature descriptions, usage examples, and NuGet/package metadata badges.