### PR TITLE
Update/20260607 xunit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    env:
+      DOTNET_NOLOGO: true
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+          cache: true
+          cache-dependency-path: |
+            **/*.csproj
+            **/*.fsproj
+            **/*.props
+            **/*.targets
+            **/nuget.config
+            global.json
+            Directory.Packages.props
+
+      - name: dotnet info
+        run: dotnet --info
+
+      - name: Restore
+        run: dotnet restore Bitai.LDAPWebApi.sln
+
+      - name: Build
+        run: dotnet build Bitai.LDAPWebApi.sln --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test Bitai.LDAPWebApi.sln --configuration Release --no-build --no-restore --verbosity normal

--- a/Bitai.LDAPWebApi.sln
+++ b/Bitai.LDAPWebApi.sln
@@ -24,6 +24,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Misc", "Misc", "{B4F14F4F-1
 		misc\LDAP Web Api development settings.json = misc\LDAP Web Api development settings.json
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{56046A85-FA83-4ED1-96A1-BB7CEF2AFD70}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bitai.LDAPWebApi.Tests", "tests\Bitai.LDAPWebApi.Tests\Bitai.LDAPWebApi.Tests.csproj", "{3A8DC079-EE73-467F-BE67-B5781EA1AA45}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{CEA55782-65D1-452E-8856-B3C28D42FE0C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -46,13 +52,20 @@ Global
 		{70681F7B-DEEB-4F1C-ABB7-C8192FD0D19B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{70681F7B-DEEB-4F1C-ABB7-C8192FD0D19B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{70681F7B-DEEB-4F1C-ABB7-C8192FD0D19B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3A8DC079-EE73-467F-BE67-B5781EA1AA45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3A8DC079-EE73-467F-BE67-B5781EA1AA45}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3A8DC079-EE73-467F-BE67-B5781EA1AA45}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3A8DC079-EE73-467F-BE67-B5781EA1AA45}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{5C4BB2FD-B967-40FE-B860-D2BBB2B5CA5C} = {CEA55782-65D1-452E-8856-B3C28D42FE0C}
+		{643F9EA8-840E-44D7-884B-1DDDE5602870} = {CEA55782-65D1-452E-8856-B3C28D42FE0C}
 		{AF559051-04E2-4FFE-8A36-81A0634B0515} = {68910433-DE7C-4D8D-917D-9103AA30F13C}
 		{70681F7B-DEEB-4F1C-ABB7-C8192FD0D19B} = {68910433-DE7C-4D8D-917D-9103AA30F13C}
+		{3A8DC079-EE73-467F-BE67-B5781EA1AA45} = {56046A85-FA83-4ED1-96A1-BB7CEF2AFD70}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DB0C2252-0846-4C49-970A-C7C68C82A4F3}

--- a/client/LDAPWebApi.Client.Demo/Program.cs
+++ b/client/LDAPWebApi.Client.Demo/Program.cs
@@ -13,7 +13,7 @@ namespace Bitai.LDAPWebApi.Clients.Demo
 			ServerCertificateCustomValidationCallback = (message, cert, chain, sslPolicyErrors) => true
 		};
 
-		static string WebApiBaseUrl = "https://localhost/LDAPWebApi";
+		static string WebApiBaseUrl = "https://localhost:5101";
 		static WebApiClientCredential ClientCredentials = new WebApiClientCredential
 		{
 			AuthorityUrl = "https://localhost/IsSts9",
@@ -22,7 +22,7 @@ namespace Bitai.LDAPWebApi.Clients.Demo
 			ClientSecret = "Bitai.LdapWebApi.Local.Machine.Client"
         };
 
-		static bool UseAccessTokenToCallLdapWebApi = true;
+		static bool UseAccessTokenToCallLdapWebApi = false;
 
 
 
@@ -45,27 +45,29 @@ namespace Bitai.LDAPWebApi.Clients.Demo
 				Console.WriteLine("Presione la tecla enter para iniciar el demo...");
 				Console.ReadLine();
 
+                Log.Warning($"{nameof(Selected_LDAPServerProfile)}: {Selected_LDAPServerProfile}");
+
                 await ServerProfilesClient_GetProfileIdsAsync();
 
                 await ServerProfilesClient_GetAllAsync();
 
                 await CatalogTypesClient_GetAllAsync();
 
-                //await UserDirectoryClient_CreateMsADUserAccountAsync();
+                await UserDirectoryClient_CreateMsADUserAccountAsync();
 
-				//await UserDirectoryClient_SetMsADUserAccountPassword();
+                await UserDirectoryClient_SetMsADUserAccountPassword();
 
-				await AuthenticationsClient_AccountAuthenticationAsync();
+                await AuthenticationsClient_AccountAuthenticationAsync();
 
-				//await UserDirectoryClient_DisableMsADUserAccount();
+                await UserDirectoryClient_DisableMsADUserAccount();
 
-				//await UserDirectoryClient_RemoveMsADUserAccount();
+                await UserDirectoryClient_RemoveMsADUserAccount();
 
-				await DirectoryClient_SearchByIdentifierAsync("srv1$");
+                await DirectoryClient_SearchByIdentifierAsync("victor.bastidas");
 
 				await UserDirectoryClient_FilterByIdentifierAsync("victor.bastidas");
 
-				await UserDirectoryClient_FilterByIdentifierAsync("???");
+				await UserDirectoryClient_FilterByIdentifierAsync("victor.bastidas");
 			}
 			catch (Exception ex)
 			{
@@ -162,7 +164,7 @@ namespace Bitai.LDAPWebApi.Clients.Demo
 
 				var credential = new LDAPCredential
 				{
-					UserAccount = "CERTUS\\vbastidas01",
+					UserAccount = $"{Selected_LDAPServerProfile}\\victor.bastidas",
 					Password = "17viko@@"
 				};
 				LogInfo(credential);
@@ -198,7 +200,7 @@ namespace Bitai.LDAPWebApi.Clients.Demo
 				Console.WriteLine($"Enter the password of the account.");
 				Console.WriteLine("(It is not nescessary to enter the real password)");
 
-				var accountCredentials = new LDAPHelper.DTO.LDAPDomainAccountCredential("BITAIVA", "victor.bastidas", requestAccountPassword("BITAIVA\\victor.bastidas"));
+				var accountCredentials = new LDAPHelper.DTO.LDAPDomainAccountCredential($"{Selected_LDAPServerProfile}", "victor.bastidas", requestAccountPassword("HOLDING\\victor.bastidas"));
 
 				LogInfo($"{nameof(client.AuthenticateAsync)}...");
 				var httpResponse = await client.AuthenticateAsync(accountCredentials, RequestLabel, UseAccessTokenToCallLdapWebApi);
@@ -229,7 +231,7 @@ namespace Bitai.LDAPWebApi.Clients.Demo
 				NewBlankLines(1);
 
 				LogInfo($"{nameof(client.DisableMsADUserAccountAsync)}...");
-				var httpResponse = await client.DisableMsADUserAccountAsync("vbastidas01", EntryAttribute.sAMAccountName, RequestLabel, UseAccessTokenToCallLdapWebApi);
+				var httpResponse = await client.DisableMsADUserAccountAsync("isaac.newton", EntryAttribute.sAMAccountName, RequestLabel, UseAccessTokenToCallLdapWebApi);
 				if (!httpResponse.IsSuccessResponse)
 				{
 					client.ThrowClientRequestException("Error al realizar la solicitud", httpResponse);
@@ -257,14 +259,14 @@ namespace Bitai.LDAPWebApi.Clients.Demo
 				NewBlankLines(1);
 
 				LogInfo($"{nameof(client.RemoveMsADUserAccountAsync)}...");
-				var httpResponse = await client.RemoveMsADUserAccountAsync("vbastidas01", EntryAttribute.sAMAccountName, RequestLabel, UseAccessTokenToCallLdapWebApi);
+				var httpResponse = await client.RemoveMsADUserAccountAsync("isaac.newton", EntryAttribute.sAMAccountName, RequestLabel, UseAccessTokenToCallLdapWebApi);
 				if (!httpResponse.IsSuccessResponse)
 				{
 					client.ThrowClientRequestException("Error al realizar la solicitud", httpResponse);
 				}
 				else
 				{
-					var result = await client.GetDTOFromResponseAsync<LDAPHelper.DTO.LDAPDisableUserAccountOperationResult>(httpResponse);
+					var result = await client.GetDTOFromResponseAsync<LDAPHelper.DTO.LDAPRemoveMsADUserAccountResult>(httpResponse);
 
 					LogInfo(result);
 				}

--- a/client/LDAPWebApi.Client.Demo/Program.cs
+++ b/client/LDAPWebApi.Client.Demo/Program.cs
@@ -13,13 +13,13 @@ namespace Bitai.LDAPWebApi.Clients.Demo
 			ServerCertificateCustomValidationCallback = (message, cert, chain, sslPolicyErrors) => true
 		};
 
-		static string WebApiBaseUrl = "https://localhost:5101";
+		static string WebApiBaseUrl = "https://localhost/LDAPWebApi";
 		static WebApiClientCredential ClientCredentials = new WebApiClientCredential
 		{
 			AuthorityUrl = "https://localhost/IsSts9",
-			ApiScope = "Bitai.LdapWebApi.Scope.Admin",
-			ClientId = "Bitai.LdapWebApi.DemoConsole.Client",
-			ClientSecret = "Bitai.LdapWebApi.DemoConsole.Client"
+			ApiScope = "Bitai.LdapWebApi.Local.ApiScope.Reader",
+			ClientId = "Bitai.LdapWebApi.Local.Machine.Client",
+			ClientSecret = "Bitai.LdapWebApi.Local.Machine.Client"
         };
 
 		static bool UseAccessTokenToCallLdapWebApi = true;

--- a/client/LDAPWebApi.Client/Bitai.LDAPWebApi.Clients.csproj
+++ b/client/LDAPWebApi.Client/Bitai.LDAPWebApi.Clients.csproj
@@ -3,15 +3,15 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Bitai.LDAPWebApi.Clients</RootNamespace>
-    <Version>10.0.0</Version>
+    <Version>10.0.1</Version>
+    <AssemblyVersion>10.0.1</AssemblyVersion>
+    <FileVersion>10.0.1</FileVersion>
     <Authors>Viko Bastidas (BITAI)</Authors>
     <Company>BITAI</Company>
     <Product>LDAP Web API</Product>
     <Description>Library to make client requests to Bitai LDAP Web API.</Description>
     <Copyright>© 2026 BITAI LDAP Web API Clients. MIT License.</Copyright>
-    <PackageIcon>api1_64.png</PackageIcon>
-    <AssemblyVersion>10.0.0</AssemblyVersion>
-    <FileVersion>10.0.0</FileVersion>
+    <PackageIcon>api1_64.png</PackageIcon>       
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageProjectUrl>https://github.com/bitai-cs/LDAPWebApi</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bitai-cs/LDAPWebApi</RepositoryUrl>
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="Bitai.LDAPHelper.DTO" Version="10.0.0" />
-    <PackageReference Include="Bitai.WebApi.Helpers" Version="10.0.0" />
+    <PackageReference Include="Bitai.WebApi.Helpers" Version="10.0.1" />
     <PackageReference Include="Duende.IdentityModel" Version="8.1.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
   </ItemGroup>

--- a/client/LDAPWebApi.Client/LDAPAuthenticationsWebApiClient.cs
+++ b/client/LDAPWebApi.Client/LDAPAuthenticationsWebApiClient.cs
@@ -59,7 +59,7 @@ namespace Bitai.LDAPWebApi.Clients
 
 
 		/// <summary>
-		/// Send a post request to LDAP Web Api Authentications controller.
+		/// Send a post request to LDAP Web Api Authentications controller, action authenticate.
 		/// </summary>
 		/// <param name="ldapCredential">Account credentials or Network credentials</param>
 		/// <param name="requestLabel">Custom tag to identify the request and mark the data returned in the response.</param>
@@ -82,5 +82,30 @@ namespace Bitai.LDAPWebApi.Clients
 				}
 			}
 		}
-	}
+
+        /// <summary>
+        /// Send a post request to LDAP Web Api Authentications controller, action authenticateWithoutUserLookup.
+        /// </summary>
+        /// <param name="ldapCredential">Account credentials or Network credentials</param>
+        /// <param name="requestLabel">Custom tag to identify the request and mark the data returned in the response.</param>
+        /// <param name="setBearerToken">Whether or not to request and / or assign the access token in the authorization HTTP header.</param>
+        /// <param name="cancellationToken">See <see cref="CancellationToken"/>.</param>
+        /// <returns><see cref="IHttpResponse"/></returns>
+        public async Task<IHttpResponse> AuthenticateWithoutUserLookupAsync(Bitai.LDAPHelper.DTO.LDAPDomainAccountCredential ldapCredential, string? requestLabel = null, bool setBearerToken = true, CancellationToken cancellationToken = default)
+        {
+            var uri = $"{WebApiBaseUrl}/api/{LDAPServerProfile}/{LDAPServerCatalogTypes.GetCatalogTypeName(UseLDAPServerGlobalCatalog)}/{ControllerNames.AuthenticationsController}/authenticateWithoutUserLookup?requestLabel={requestLabel}";
+
+            using (var httpClient = await CreateHttpClient(setBearerToken))
+            {
+                using (var content = new ObjectContent<LDAPHelper.DTO.LDAPDomainAccountCredential>(ldapCredential, new JsonMediaTypeFormatter()))
+                {
+                    var responseMessage = await httpClient.PostAsync(uri, content, cancellationToken);
+                    if (!responseMessage.IsSuccessStatusCode)
+                        return await responseMessage.ToUnsuccessfulHttpResponseAsync();
+                    else
+                        return await responseMessage.ToSuccessfulHttpResponseAsync<LDAPHelper.DTO.LDAPDomainAccountAuthenticationResult>();
+                }
+            }
+        }
+    }
 }

--- a/src/LDAPWebApi/Bitai.LDAPWebApi.csproj
+++ b/src/LDAPWebApi/Bitai.LDAPWebApi.csproj
@@ -5,13 +5,13 @@
 		<RootNamespace>Bitai.LDAPWebApi</RootNamespace>
 		<AssemblyName>Bitai.LDAPWebApi</AssemblyName>
 		<UserSecretsId>d895caed-ec5c-4dfe-b5f1-1d6df1609afe</UserSecretsId>
-		<Version>10.0.0</Version>
-		<AssemblyVersion>10.0.0</AssemblyVersion>
+		<Version>10.0.1</Version>
+		<AssemblyVersion>10.0.1</AssemblyVersion>
+        <FileVersion>10.0.1</FileVersion>
 		<Authors>Viko Bastidas (BITAI)</Authors>
 		<Company>BITAI</Company>
 		<Product>LDAP Web API</Product>
-		<Nullable>enable</Nullable>
-		<FileVersion>10.0.0</FileVersion>
+		<Nullable>enable</Nullable>		
 		<Description>Web API that provides access to an LDAP server</Description>
 		<PackageProjectUrl>https://github.com/bitai-cs/LDAPWebApi</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/bitai-cs/LDAPWebApi</RepositoryUrl>
@@ -40,9 +40,9 @@
 	  <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
 	  <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
 	  <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
-	  <PackageReference Include="Bitai.LDAPHelper" Version="10.1.0" />
+	  <PackageReference Include="Bitai.LDAPHelper" Version="10.1.2" />
 	  <PackageReference Include="Bitai.LDAPHelper.Tests.Mocks" Version="10.1.0" />
-	  <PackageReference Include="Bitai.WebApi.Helpers" Version="10.0.0" />
+	  <PackageReference Include="Bitai.WebApi.Helpers" Version="10.0.1" />
 	  <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
 	  <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
 	  <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />

--- a/src/LDAPWebApi/Bitai.LDAPWebApi.csproj
+++ b/src/LDAPWebApi/Bitai.LDAPWebApi.csproj
@@ -40,7 +40,8 @@
 	  <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
 	  <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
 	  <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
-	  <PackageReference Include="Bitai.LDAPHelper" Version="10.0.0" />
+	  <PackageReference Include="Bitai.LDAPHelper" Version="10.1.0" />
+	  <PackageReference Include="Bitai.LDAPHelper.Tests.Mocks" Version="10.1.0" />
 	  <PackageReference Include="Bitai.WebApi.Helpers" Version="10.0.0" />
 	  <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
 	  <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />

--- a/src/LDAPWebApi/Configurations/Application/WebApiConfiguration.cs
+++ b/src/LDAPWebApi/Configurations/Application/WebApiConfiguration.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 namespace Bitai.LDAPWebApi.Configurations.App;
 
 /// <summary>
-/// Web Api configuration model 
+/// Web Api _configuration model 
 /// </summary>
 public class WebApiConfiguration
 {
@@ -59,11 +59,11 @@ public class WebApiConfiguration
 	/// </summary>
 	public string WebApiContactUrl { get; set; }
 	/// <summary>
-	/// Web API health checks configuration
+	/// Web API health checks _configuration
 	/// </summary>
 	public WebApiHealthChecksConfiguration HealthChecksConfiguration { get; set; }
     /// <summary>
-    /// Web API testing configuration
+    /// Web API testing _configuration
     /// </summary>
     public WebApiTestConfiguration TestConfiguration { get; set; }
 
@@ -72,7 +72,7 @@ public class WebApiConfiguration
 
     #region Inner classes
     /// <summary>
-    /// Web API health checks configuration model
+    /// Web API health checks _configuration model
     /// </summary>
     public class WebApiHealthChecksConfiguration
 	{
@@ -128,7 +128,7 @@ public class WebApiConfiguration
 	}
 
     /// <summary>
-    /// Web API testing configuration model
+    /// Web API testing _configuration model
     /// </summary>
     public class WebApiTestConfiguration
     {

--- a/src/LDAPWebApi/Configurations/Application/WebApiConfiguration.cs
+++ b/src/LDAPWebApi/Configurations/Application/WebApiConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -24,7 +24,8 @@ public class WebApiConfiguration
 		WebApiContactUrl = "https://www.linkedin.com/in/victorbastidasg";
 
 		HealthChecksConfiguration = new WebApiHealthChecksConfiguration();
-	}
+        TestConfiguration = new WebApiTestConfiguration();
+    }
 
 
 
@@ -61,12 +62,19 @@ public class WebApiConfiguration
 	/// Web API health checks configuration
 	/// </summary>
 	public WebApiHealthChecksConfiguration HealthChecksConfiguration { get; set; }
+    /// <summary>
+    /// Web API testing configuration
+    /// </summary>
+    public WebApiTestConfiguration TestConfiguration { get; set; }
 
-	#region Inner class
-	/// <summary>
-	/// Web API health checks configuration model
-	/// </summary>
-	public class WebApiHealthChecksConfiguration
+
+
+
+    #region Inner classes
+    /// <summary>
+    /// Web API health checks configuration model
+    /// </summary>
+    public class WebApiHealthChecksConfiguration
 	{
 		/// <summary>
 		/// Constructor
@@ -118,5 +126,27 @@ public class WebApiConfiguration
         /// </summary>
         public int EvaluationTime { get; set; }
 	}
+
+    /// <summary>
+    /// Web API testing configuration model
+    /// </summary>
+    public class WebApiTestConfiguration
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public WebApiTestConfiguration()
+        {
+            EnablePersistentMockLdapDataStore = false;
+        }
+
+
+
+
+        /// <summary>
+        /// Indicates whether API testing mode will be enabled or not.
+        /// </summary>
+        public bool EnablePersistentMockLdapDataStore { get; set; }     
+    }
 	#endregion
 }

--- a/src/LDAPWebApi/Configurations/Application/WebApiCorsConfiguration.cs
+++ b/src/LDAPWebApi/Configurations/Application/WebApiCorsConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 namespace Bitai.LDAPWebApi.Configurations.App;
 
 /// <summary>
-/// Web Api CORS configuration model 
+/// Web Api CORS _configuration model 
 /// </summary>
 public class WebApiCorsConfiguration
 {

--- a/src/LDAPWebApi/Configurations/Application/WebApiLogConfiguration.cs
+++ b/src/LDAPWebApi/Configurations/Application/WebApiLogConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using Serilog;
+using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace Bitai.LDAPWebApi.Configurations.App;
 
 /// <summary>
-/// Web Api log configuration model 
+/// Web Api log _configuration model 
 /// </summary>
 public class WebApiLogConfiguration
 {
@@ -105,22 +105,22 @@ public class WebApiLogConfiguration
 
 
     /// <summary>
-    /// Console log configuration
+    /// Console log _configuration
     /// </summary>
     public ConsoleLogSetup ConsoleLog { get; set; }
 
     /// <summary>
-    /// File log configuration
+    /// File log _configuration
     /// </summary>
     public FileLogSetup FileLog { get; set; }
 
     /// <summary>
-    /// Grafana Loki log configuration
+    /// Grafana Loki log _configuration
     /// </summary>
     public GrafanaLokiLogSetup GrafanaLokiLog { get; set; }
 
     /// <summary>
-    /// Elasticsearch log configuration
+    /// Elasticsearch log _configuration
     /// </summary> 
     public ElasticsearchLogSetup ElasticsearchLog { get; set; }
 

--- a/src/LDAPWebApi/Configurations/Application/WebApiScopesConfiguration.cs
+++ b/src/LDAPWebApi/Configurations/Application/WebApiScopesConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 namespace Bitai.LDAPWebApi.Configurations.App;
 
 /// <summary>
-/// Web Api scopes configuration model
+/// Web Api scopes _configuration model
 /// </summary>
 public class WebApiScopesConfiguration
 {

--- a/src/LDAPWebApi/Configurations/LDAP/LDAPServerProfiles.cs
+++ b/src/LDAPWebApi/Configurations/LDAP/LDAPServerProfiles.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -21,7 +21,7 @@ public class LDAPServerProfiles : List<LDAPServerProfile>
 			.Select(g => g.Key);
 
 		if (repeatedProfileIds.Count() > 0)
-			throw new Exception($"Error in {nameof(LDAPServerProfiles)} configuration. There are repeating {nameof(LDAPServerProfile.ProfileId)}s: {string.Join(',', repeatedProfileIds)}");
+			throw new Exception($"Error in {nameof(LDAPServerProfiles)} _configuration. There are repeating {nameof(LDAPServerProfile.ProfileId)}s: {string.Join(',', repeatedProfileIds)}");
 		#endregion
 
 		#region Validate profiles without DefaultDomainName
@@ -31,7 +31,7 @@ public class LDAPServerProfiles : List<LDAPServerProfile>
 		{
 			var invalidProfiles = string.Join(",", profilesWithoutDefaultDomainName.Select(p => p.ProfileId));
 
-			throw new Exception($"Error in {nameof(LDAPServerProfiles)} configuration. There are {nameof(LDAPServerProfile)}s without {nameof(LDAPServerProfile.DefaultDomainName)}: {invalidProfiles}");
+			throw new Exception($"Error in {nameof(LDAPServerProfiles)} _configuration. There are {nameof(LDAPServerProfile)}s without {nameof(LDAPServerProfile.DefaultDomainName)}: {invalidProfiles}");
 		}
 		#endregion
 	}

--- a/src/LDAPWebApi/Configurations/Security/AuthorityConfiguration.cs
+++ b/src/LDAPWebApi/Configurations/Security/AuthorityConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 namespace Bitai.LDAPWebApi.Configurations.Security;
 
 /// <summary>
-/// Identity Server authority configuration model.
+/// Identity Server authority _configuration model.
 /// </summary>
 public class AuthorityConfiguration
 {

--- a/src/LDAPWebApi/Configurations/Swagger/SwaggerUIConfiguration.cs
+++ b/src/LDAPWebApi/Configurations/Swagger/SwaggerUIConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 namespace Bitai.LDAPWebApi.Configurations.Swagger;
 
 /// <summary>
-/// Identity Server authority configuration model.
+/// Identity Server authority _configuration model.
 /// </summary>
 public class SwaggerUIConfiguration
 {

--- a/src/LDAPWebApi/Controllers/ApiControllerBase.cs
+++ b/src/LDAPWebApi/Controllers/ApiControllerBase.cs
@@ -193,33 +193,33 @@ public abstract class ApiControllerBase<T> : ControllerBase
 		return searchFilters.combineFilters.Value;
 	}
 
-	/// <summary>
-	/// Search for a user account.
-	/// </summary>
-	/// <param name="clientConfiguration"></param>
-	/// <param name="userAccountIdentifier"></param>
-	/// <param name="userAccountIdentifierAttribute"></param>
-	/// <param name="requestLabel"></param>
-	/// <returns></returns>
-	protected Task<LDAPSearchResult> SearchUserAccountAsync(LDAPHelper.ClientConfiguration clientConfiguration, string userAccountIdentifier, EntryAttribute userAccountIdentifierAttribute, string requestLabel)
-	{
-		var searcher = GetLdapSearcher(clientConfiguration);
-		var searchFilter = new AttributeFilterCombiner(false, true, new ICombinableFilter[] { AttributeFilterCombiner.CreateOnlyUsersFilterCombiner(), new AttributeFilter(userAccountIdentifierAttribute, new FilterValue(userAccountIdentifier)) });
+	///// <summary>
+	///// Search for a user account.
+	///// </summary>
+	///// <param name="clientConfiguration"></param>
+	///// <param name="userAccountIdentifier"></param>
+	///// <param name="userAccountIdentifierAttribute"></param>
+	///// <param name="requestLabel"></param>
+	///// <returns></returns>
+	//protected Task<LDAPSearchResult> SearchUserAccountAsync(LDAPHelper.ClientConfiguration clientConfiguration, string userAccountIdentifier, EntryAttribute userAccountIdentifierAttribute, string requestLabel)
+	//{
+	//	var searcher = GetLdapSearcher(clientConfiguration);
+	//	var searchFilter = new AttributeFilterCombiner(false, true, new ICombinableFilter[] { AttributeFilterCombiner.CreateOnlyUsersFilterCombiner(), new AttributeFilter(userAccountIdentifierAttribute, new FilterValue(userAccountIdentifier)) });
 
-		return searcher.SearchEntriesAsync(searchFilter, RequiredEntryAttributes.Minimun, requestLabel);
-	}
+	//	return searcher.SearchEntriesAsync(searchFilter, RequiredEntryAttributes.Minimun, requestLabel);
+	//}
 
-	/// <summary>
-	/// Throw an error according to the response of an unsuccessful operation.
-	/// </summary>
-	/// <param name="exceptionMessage"></param>
-	/// <param name="unsuccessfulOperation"></param>
-	/// <exception cref="Exception"></exception>
-	protected void ThrowExceptionForUnsuccessfulOperation(string exceptionMessage, LDAPOperationResult unsuccessfulOperation)
-	{
-		if (unsuccessfulOperation.HasErrorObject)
-			throw new Exception(exceptionMessage, unsuccessfulOperation.ErrorObject);
-		else
-			throw new Exception($"{exceptionMessage}. {unsuccessfulOperation.OperationMessage}");
-	}
+	///// <summary>
+	///// Throw an error according to the response of an unsuccessful operation.
+	///// </summary>
+	///// <param name="exceptionMessage"></param>
+	///// <param name="unsuccessfulOperation"></param>
+	///// <exception cref="Exception"></exception>
+	//protected void ThrowExceptionForUnsuccessfulOperation(string exceptionMessage, LDAPOperationResult unsuccessfulOperation)
+	//{
+	//	if (unsuccessfulOperation.HasErrorObject)
+	//		throw new Exception(exceptionMessage, unsuccessfulOperation.ErrorObject);
+	//	else
+	//		throw new Exception($"{exceptionMessage}. {unsuccessfulOperation.OperationMessage}");
+	//}
 }

--- a/src/LDAPWebApi/Controllers/AuthenticationsController.cs
+++ b/src/LDAPWebApi/Controllers/AuthenticationsController.cs
@@ -42,9 +42,9 @@ public class AuthenticationsController : ApiControllerBase<AuthenticationsContro
 		[FromQuery][ModelBinder(BinderType = typeof(Binders.OptionalQueryStringBinder))] string requestLabel,
 		[FromBody] LDAPDomainAccountCredential credential)
 	{
-		Logger.LogInformation("Request path: {serverProfileRoute}={serverProfile}, {catalogTypeRoute}={catalogType}, {requestLabelQuery}={requestLabel}", nameof(serverProfile), serverProfile, nameof(catalogType), catalogType, nameof(requestLabel), requestLabel);
-
-		Logger.LogInformation("Request body: {@credential}", credential.SecureClone());
+		Logger.LogInformation("Endpoint Routes: {serverProfileRoute}={serverProfile}, {catalogTypeRoute}={catalogType}, {requestLabelQuery}={requestLabel}", nameof(serverProfile), serverProfile, nameof(catalogType), catalogType, nameof(requestLabel), requestLabel);
+        Logger.LogInformation("Endpoint Method: {method}", nameof(AuthenticateAsync));
+        Logger.LogInformation("Endpoint Paylod: {@credential}", credential.SecureClone());
 
 		var ldapClientConfig = GetLdapClientConfiguration(serverProfile.ToString(), IsGlobalCatalog(catalogType), out var ldapServerProfile);
 
@@ -59,7 +59,7 @@ public class AuthenticationsController : ApiControllerBase<AuthenticationsContro
 			Logger.LogError("Failed to authenticate user account {domainAccountName}.", credential.DomainAccountName);
 
 			if (authenticationResult.HasErrorObject)
-				throw authenticationResult.ErrorObject;
+				throw new Exception(authenticationResult.OperationMessage, authenticationResult.ErrorObject);
 			else
 				throw new Exception(authenticationResult.OperationMessage);
 		}
@@ -68,4 +68,49 @@ public class AuthenticationsController : ApiControllerBase<AuthenticationsContro
 
 		return Ok(authenticationResult);
 	}
+
+    /// <summary>
+	/// Authenticate a domain username without validating whether the username exists or not.
+	/// </summary>
+	/// <param name="serverProfile">LDAP Server Profile Id that defines part of the path. See <see cref="Configurations.LDAP.LDAPServerProfile"/></param>
+	/// <param name="catalogType">Name of the LDAP catalog that defines part of the path. See <see cref="DTO.LDAPServerCatalogTypes"/></param>
+	/// <param name="credential">Account credential to validate. See <see cref="LDAPDomainAccountCredential"/></param>
+	/// <param name="requestLabel">Label to tag the results. Optional, it can be null</param>
+	/// <returns><see cref="LDAPDomainAccountAuthenticationResult"/></returns>
+	[Authorize(WebApiScopesConfiguration.AuthorizationPolicyForAnyApiScopeName)]
+    [HttpPost]
+    [Route("{serverProfile:ldapSvrPf}/{catalogType:ldapCatType}/[controller]/[action]")]
+    [ActionName("authenticateWithoutUserLookup")]
+    public async Task<ActionResult<LDAPDomainAccountAuthenticationResult>> AuthenticateWithoutUserLookupAsync(
+        [FromRoute] string serverProfile,
+        [FromRoute] string catalogType,
+        [FromQuery][ModelBinder(BinderType = typeof(Binders.OptionalQueryStringBinder))] string requestLabel,
+        [FromBody] LDAPDomainAccountCredential credential)
+    {
+        Logger.LogInformation("Endpoint Routes: {serverProfileRoute}={serverProfile}, {catalogTypeRoute}={catalogType}, {requestLabelQuery}={requestLabel}", nameof(serverProfile), serverProfile, nameof(catalogType), catalogType, nameof(requestLabel), requestLabel);
+        Logger.LogInformation("Endpoint Method: {method}", nameof(AuthenticateWithoutUserLookupAsync));
+        Logger.LogInformation("Endpoint Payload: {@credential}", credential.SecureClone());
+
+        var ldapClientConfig = GetLdapClientConfiguration(serverProfile.ToString(), IsGlobalCatalog(catalogType), out var ldapServerProfile);
+
+        var authenticator = GetAuthenticator(ldapClientConfig.ServerSettings);
+
+        if (string.IsNullOrEmpty(credential.DomainName))
+            credential.DomainName = ldapServerProfile.DefaultDomainName;
+
+        var authenticationResult = await authenticator.AuthenticateAsync(credential, requestLabel);
+        if (!authenticationResult.IsSuccessfulOperation)
+        {
+            Logger.LogError("Failed to authenticate user account {domainAccountName}.", credential.DomainAccountName);
+
+            if (authenticationResult.HasErrorObject)
+                throw new Exception(authenticationResult.OperationMessage, authenticationResult.ErrorObject);
+            else
+                throw new Exception(authenticationResult.OperationMessage);
+        }
+
+        Logger.LogInformation("Response body: {@authenticationResult}", authenticationResult);
+
+        return Ok(authenticationResult);
+    }
 }

--- a/src/LDAPWebApi/Controllers/DirectoryController.cs
+++ b/src/LDAPWebApi/Controllers/DirectoryController.cs
@@ -1,11 +1,14 @@
-using Bitai.LDAPHelper.LdapAdapters;
+using System.Data;
+using Bitai.LDAPHelper;
 using Bitai.LDAPHelper.DTO;
+using Bitai.LDAPHelper.LdapAdapters;
 using Bitai.LDAPHelper.QueryFilters;
 using Bitai.LDAPWebApi.Configurations.App;
 using Bitai.LDAPWebApi.DTO;
 using Bitai.WebApi.Server;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Novell.Directory.Ldap;
 
 namespace Bitai.LDAPWebApi.Controllers;
 
@@ -64,15 +67,20 @@ public class DirectoryController : ApiControllerBase<DirectoryController>
 
 		if (!searchResult.IsSuccessfulOperation)
 		{
-			if (searchResult.HasErrorObject)
-			{
-				Logger.LogError(searchResult.ErrorObject, "Search failed by {@ida} identifier with value {@id}.", identifierAttribute, identifier);
+            if (searchResult.HasErrorObject)
+            {
+                if (searchResult.ErrorObject is LdapException)
+                {
+                    var unwrappedLdapException = (LdapException)searchResult.ErrorObject;
 
-				throw searchResult.ErrorObject;
-			}
-			else
-				throw new Exception(searchResult.OperationMessage);
-		}
+                    throw new LdapException(searchResult.OperationMessage, unwrappedLdapException.ResultCode, unwrappedLdapException.LdapErrorMessage, unwrappedLdapException);
+                }
+                else
+                    throw new Exception(searchResult.OperationMessage, searchResult.ErrorObject);
+            }
+            else
+                throw new Exception(searchResult.OperationMessage);
+        }
 
 		if (searchResult.Entries.Count() == 0)
 			throw new ResourceNotFoundException($"The user with identifier {identifierAttribute}={identifier} was not found");
@@ -85,17 +93,18 @@ public class DirectoryController : ApiControllerBase<DirectoryController>
 		return Ok(searchResult);
 	}
 
-	/// <summary>
-	/// Search directory entries based on the specified filters.
-	/// </summary>
-	/// <param name="serverProfile">LDAP Server profile Id.</param>
-	/// <param name="catalogType">LDAP Server catalog type.</param>
-	/// <param name="searchFilters"><see cref="Models.SearchFiltersModel"/> that encapsulates attribute filters in query string.</param>
-	/// <param name="requiredAttributes">Type of LDAP attribute set that the response should return. If no value is assigned, <see cref="RequiredEntryAttributes.Few"/> is assumed by default. This is an optional query string parameter.</param>
-	/// <param name="requestLabel">Custom tag that identifies the request and marks the data returned in the response. This is an optional query string parameter.</param>
-	/// <returns><see cref="LDAPSearchResult"/></returns>
-	/// <exception cref="ApplicationException">When an <see cref="LDAPHelper"/> operation does not complete successfully.</exception>
-	[Authorize(WebApiScopesConfiguration.AuthorizationPolicyForAnyApiScopeName)]
+    /// <summary>
+    /// Search directory entries based on the specified filters.
+    /// </summary>
+    /// <param name="serverProfile">LDAP Server profile Id.</param>
+    /// <param name="catalogType">LDAP Server catalog type.</param>
+    /// <param name="searchFilters"><see cref="Models.SearchFiltersModel"/> that encapsulates attribute filters in query string.</param>
+    /// <param name="requiredAttributes">Type of LDAP attribute set that the response should return. If no value is assigned, <see cref="RequiredEntryAttributes.Few"/> is assumed by default. This is an optional query string parameter.</param>
+    /// <param name="requestLabel">Custom tag that identifies the request and marks the data returned in the response. This is an optional query string parameter.</param>
+    /// <returns><see cref="LDAPSearchResult"/></returns>
+    /// <exception cref="LdapException">When an LDAP error interrup a <see cref="DirectoryController"/> operation.</exception>
+    /// <exception cref="Exception">When an <see cref="DirectoryController"/> operation does not complete successfully.</exception>
+    [Authorize(WebApiScopesConfiguration.AuthorizationPolicyForAnyApiScopeName)]
 	[HttpGet]
 	[Route("{serverProfile:ldapSvrPf}/{catalogType:ldapCatType}/[controller]/[action]")]
 	[ActionName("filterBy")]
@@ -134,15 +143,20 @@ public class DirectoryController : ApiControllerBase<DirectoryController>
 
 		if (!searchResult.IsSuccessfulOperation)
 		{
-			if (searchResult.HasErrorObject)
-			{
-				Logger.LogError(searchResult.ErrorObject, "Error when performing the search for LDAP entries by the filter: {@searchFilters}", searchFilters);
+            if (searchResult.HasErrorObject)
+            {
+                if (searchResult.ErrorObject is LdapException)
+                {
+                    var unwrappedLdapException = (LdapException)searchResult.ErrorObject;
 
-				throw searchResult.ErrorObject;
-			}
-			else
-				throw new ApplicationException(searchResult.OperationMessage);
-		}
+                    throw new LdapException(searchResult.OperationMessage, unwrappedLdapException.ResultCode, unwrappedLdapException.LdapErrorMessage, unwrappedLdapException);
+                }
+                else
+                    throw new Exception(searchResult.OperationMessage, searchResult.ErrorObject);
+            }
+            else
+                throw new Exception(searchResult.OperationMessage);
+        }
 
 		Logger.LogInformation("Search result count: {0}", searchResult.Entries.Count());
 
@@ -162,7 +176,7 @@ public class DirectoryController : ApiControllerBase<DirectoryController>
 	[Authorize(WebApiScopesConfiguration.AuthorizationPolicyForAdminApiScopeName)]
 	[HttpPost]
 	[Route("{serverProfile:ldapSvrPf}/{catalogType:ldapCatType}/[controller]/MsADUsers")]
-	public async Task<ActionResult<LDAPCreateMsADUserAccountResult>> CreateUserAccountForMsAD(
+	public async Task<ActionResult<LDAPCreateMsADUserAccountResult>> CreateMsADUserAccount(
 		[FromRoute] string serverProfile,
 		[FromRoute] string catalogType,
 		[FromQuery][ModelBinder(BinderType = typeof(Binders.OptionalQueryStringBinder))] string requestLabel,
@@ -178,58 +192,23 @@ public class DirectoryController : ApiControllerBase<DirectoryController>
 		var accountManager = GetAccountManager(clientConfig);
 		accountManager.InitializeMissingMsADUserAccountDN(newUserAccount);
 
-		#region Check if DN already exists
-		var onlyUsersFilterCombiner = LDAPHelper.QueryFilters.AttributeFilterCombiner.CreateOnlyUsersFilterCombiner();
-		var attributeFilter = new LDAPHelper.QueryFilters.AttributeFilter(EntryAttribute.distinguishedName, new LDAPHelper.QueryFilters.FilterValue(newUserAccount.DistinguishedName));
-		var searchFilterCombiner = new LDAPHelper.QueryFilters.AttributeFilterCombiner(false, true, new List<LDAPHelper.QueryFilters.ICombinableFilter> { onlyUsersFilterCombiner, attributeFilter });
-
-		var searcher = GetLdapSearcher(clientConfig);
-		var searchResult = await searcher.SearchEntriesAsync(searchFilterCombiner, RequiredEntryAttributes.Minimun, requestLabel);
-		if (!searchResult.IsSuccessfulOperation)
-		{
-			if (searchResult.HasErrorObject)
-				throw searchResult.ErrorObject;
-			else
-				throw new Exception(searchResult.OperationMessage);
-		}
-		if (searchResult.Entries.Count() != 0)
-		{
-			throw new ConflictException($"There is already an entry in the AD with the {EntryAttribute.distinguishedName} equal to {newUserAccount.DistinguishedName}");
-		}
-		#endregion
-
-		#region Check if samAccountName already exists
-		attributeFilter = new LDAPHelper.QueryFilters.AttributeFilter(EntryAttribute.sAMAccountName, new LDAPHelper.QueryFilters.FilterValue(newUserAccount.SAMAccountName));
-		searchFilterCombiner = new LDAPHelper.QueryFilters.AttributeFilterCombiner(false, true, new List<LDAPHelper.QueryFilters.ICombinableFilter> { onlyUsersFilterCombiner, attributeFilter });
-
-		searchResult = await searcher.SearchEntriesAsync(searchFilterCombiner, RequiredEntryAttributes.Minimun, requestLabel);
-		if (!searchResult.IsSuccessfulOperation)
-		{
-			if (searchResult.HasErrorObject)
-				throw searchResult.ErrorObject;
-			else
-				throw new Exception(searchResult.OperationMessage);
-		}
-		if (searchResult.Entries.Count() != 0)
-		{
-			throw new ConflictException($"There is already an entry in the AD with the {EntryAttribute.sAMAccountName} equal to {newUserAccount.SAMAccountName}");
-		}
-		#endregion
-
 		var createUserAccountResult = await accountManager.CreateUserAccountForMsAD(newUserAccount, requestLabel);
 		if (!createUserAccountResult.IsSuccessfulOperation)
 		{
 			if (createUserAccountResult.HasErrorObject)
 			{
-				Logger.LogError(createUserAccountResult.ErrorObject, "Error creating user account {@ua}", newUserAccount.SecureClone());
-
-				throw createUserAccountResult.ErrorObject;
+                if (createUserAccountResult.ErrorObject is DataValidationException)
+                    throw new BadRequestException(createUserAccountResult.OperationMessage, createUserAccountResult.ErrorObject);
+                if (createUserAccountResult.ErrorObject is DuplicateNameException)
+                    throw new ConflictException(createUserAccountResult.OperationMessage, createUserAccountResult.ErrorObject);
+                else
+				    throw new Exception(createUserAccountResult.OperationMessage,  createUserAccountResult.ErrorObject);
 			}
 			else
 				throw new Exception(createUserAccountResult.OperationMessage);
 		}
 
-		Logger.LogInformation("Response body: {@pwdUpdateResult}", createUserAccountResult);
+		Logger.LogInformation("Response body: {@createUserAccountResult}", createUserAccountResult);
 
 		return Ok(createUserAccountResult);
 	}
@@ -270,61 +249,67 @@ public class DirectoryController : ApiControllerBase<DirectoryController>
 		{
 			var strings = credential.UserAccount.Split('\\', StringSplitOptions.None);
 			if (!strings[0].Equals(serverProfileObject.DefaultDomainName, StringComparison.OrdinalIgnoreCase))
-				throw new BadRequestException($"The {strings[0]} domain of the user account {strings[1]} must be the same as the {serverProfile} domain specified in the API route.");
+				throw new BadRequestException($"The {strings[0]} domain of the usename {strings[1]} must be the same as the {serverProfile} domain specified in the API route.");
 
 			if (!strings[1].Equals(identifier, StringComparison.OrdinalIgnoreCase))
-				throw new BadHttpRequestException($"The user account {strings[1]} must be the same as the {identifier} identifier specified in the API route.");
+				throw new BadRequestException($"The usernme {strings[1]} must be the same as the {identifier} identifier specified in the API route.");
 
 			domainName = strings[0];
 			userAccount = strings[1];
 		}
 		else
 		{
-			domainName = serverProfileObject.DefaultDomainName;
+            if (!credential.UserAccount.Equals(identifier, StringComparison.OrdinalIgnoreCase))
+                throw new BadRequestException($"The user account {credential.UserAccount} must be the same as the {identifier} identifier specified in the API route.");
+
+            domainName = serverProfileObject.DefaultDomainName;
 			userAccount = credential.UserAccount;
 		}
 
-		var clientConfig = GetLdapClientConfiguration(serverProfile, IsGlobalCatalog(catalogType));
-		var searcher = GetLdapSearcher(clientConfig);
-		var onlyUsersFilter = AttributeFilterCombiner.CreateOnlyUsersFilterCombiner();
-		var attributeFilter = new AttributeFilter(identifierAttribute.Value, new FilterValue(identifier));
-		var searchFilter = new AttributeFilterCombiner(false, true, new ICombinableFilter[] { onlyUsersFilter, attributeFilter });
-		var searchResult = await searcher.SearchEntriesAsync(searchFilter, RequiredEntryAttributes.Minimun, requestLabel);
-		if (!searchResult.IsSuccessfulOperation)
-		{
-			if (searchResult.HasErrorObject)
-			{
-				Logger.LogError(searchResult.ErrorObject, "Failed to search for a domain user account based on search filter {@searchFilter}", searchFilter);
+		//var clientConfig = GetLdapClientConfiguration(serverProfile, IsGlobalCatalog(catalogType));
+		//var searcher = GetLdapSearcher(clientConfig);
+		//var onlyUsersFilter = AttributeFilterCombiner.CreateOnlyUsersFilterCombiner();
+		//var attributeFilter = new AttributeFilter(identifierAttribute.Value, new FilterValue(identifier));
+		//var searchFilter = new AttributeFilterCombiner(false, true, new ICombinableFilter[] { onlyUsersFilter, attributeFilter });
+		//var searchResult = await searcher.SearchEntriesAsync(searchFilter, RequiredEntryAttributes.Minimun, requestLabel);
+		//if (!searchResult.IsSuccessfulOperation)
+		//{
+		//	if (searchResult.HasErrorObject)
+		//	{
+		//		Logger.LogError(searchResult.ErrorObject, "Failed to search for a domain user account based on search filter {@searchFilter}", searchFilter);
 
-				throw searchResult.ErrorObject;
-			}
-			else
-				throw new Exception(searchResult.OperationMessage);
-		}
+		//		throw searchResult.ErrorObject;
+		//	}
+		//	else
+		//		throw new Exception(searchResult.OperationMessage);
+		//}
 
-		if (searchResult.Entries.Count() == 0)
-			throw new ResourceNotFoundException($"The user accoun with identifier {attributeFilter} was not found");
+		//if (searchResult.Entries.Count() == 0)
+		//	throw new ResourceNotFoundException($"The user accoun with identifier {attributeFilter} was not found");
 
-		if (searchResult.Entries.Count() > 1)
-			throw new BadRequestException($"More than one LDAP entry was obtained for the supplied identifier {attributeFilter}.");
+		//if (searchResult.Entries.Count() > 1)
+		//	throw new BadRequestException($"More than one LDAP entry was obtained for the supplied identifier {attributeFilter}.");
 
-		var entry = searchResult.Entries.Single();
+		//var entry = searchResult.Entries.Single();
 
-		var dnCredential = new LDAPDistinguishedNameCredential(entry.distinguishedName, credential.Password);
+		//var dnCredential = new LDAPDistinguishedNameCredential(entry.distinguishedName, credential.Password);
 		var accountManager = GetAccountManager(GetLdapClientConfiguration(serverProfile, IsGlobalCatalog(catalogType)));
-		var pwdUpdateResult = await accountManager.SetUserAccountPasswordForMsAD(dnCredential, requestLabel);
+		var pwdUpdateResult = await accountManager.SetMsADUserAccountPassword(identifierAttribute.Value, userAccount, credential.Password, requestLabel);
 
 		if (!pwdUpdateResult.IsSuccessfulOperation)
 		{
-			if (pwdUpdateResult.HasErrorObject)
-			{
-				Logger.LogError(pwdUpdateResult.ErrorObject, "Failed password assignment for user account {identifier} with {distinguishedName}: {distinguishedNameValue}", identifier, EntryAttribute.distinguishedName, dnCredential.DistinguishedName);
-
-				throw pwdUpdateResult.ErrorObject;
-			}
-			else
-				throw new Exception(pwdUpdateResult.OperationMessage);
-		}
+            if (pwdUpdateResult.HasErrorObject)
+            {
+                if (pwdUpdateResult.ErrorObject is EntryNotFoundException)
+                    throw new ResourceNotFoundException(pwdUpdateResult.OperationMessage, pwdUpdateResult.ErrorObject);
+                else if (pwdUpdateResult.ErrorObject is DataValidationException)
+                    throw new BadRequestException(pwdUpdateResult.OperationMessage, pwdUpdateResult.ErrorObject);
+                else
+                    throw new Exception(pwdUpdateResult.OperationMessage, pwdUpdateResult.ErrorObject);
+            }
+            else
+                throw new Exception(pwdUpdateResult.OperationMessage);
+        }
 
 		Logger.LogInformation("Response body: {@pwdUpdateResult}", pwdUpdateResult);
 
@@ -354,31 +339,27 @@ public class DirectoryController : ApiControllerBase<DirectoryController>
 		Logger.LogInformation("Request path: {@spn}={@sp}, {@ctn}={@ct}, {@idn}={@id}, {@idan}={@ida}, {@rtn}={@rt}", nameof(serverProfile), serverProfile, nameof(catalogType), catalogType, nameof(identifier), identifier, nameof(identifierAttribute), identifierAttribute, nameof(requestLabel), requestLabel);
 
 		if (!catalogType.Equals(CatalogTypeRoutes.LocalCatalog, StringComparison.OrdinalIgnoreCase))
-			throw new BadRequestException("No se puede eliminar la cuenta de usuario en el catálogo global de un servidor LDAP. Esta operación solo está permitida en el catálogo local de un servidor LDAP.");
+			throw new BadRequestException("User account deletion from the LDAP server’s global catalog is not permitted. This operation is only allowed in the LDAP server’s local catalog.");
 
 		var clientConfig = GetLdapClientConfiguration(serverProfile, IsGlobalCatalog(catalogType));
 
-		string distinguishedName = identifier;
-		if (identifierAttribute == EntryAttribute.sAMAccountName)
-		{
-			var searchResult = await SearchUserAccountAsync(clientConfig, identifier, identifierAttribute.Value, requestLabel);
-
-			if (searchResult.IsSuccessfulOperation)
-			{
-				if (searchResult.Entries.Count() == 0)
-					throw new ResourceNotFoundException($"There is no user account according to the criteria {identifierAttribute} = {identifier}");
-
-				distinguishedName = searchResult.Entries.Single().distinguishedName;
-			}
-			else
-				ThrowExceptionForUnsuccessfulOperation($"Failed to disable user account {identifier}.", searchResult);
-		}
-
 		var accountManager = GetAccountManager(clientConfig);
-
-		var disableResult = await accountManager.DisableUserAccountForMsAD(distinguishedName, requestLabel);
+		var disableResult = await accountManager.DisableMsADUserAccount(identifierAttribute.Value, identifier, requestLabel);
 		if (!disableResult.IsSuccessfulOperation)
-			ThrowExceptionForUnsuccessfulOperation($"Failed to disable user account {identifier}.", disableResult);
+        {
+            if (disableResult.HasErrorObject)
+            {
+                if (disableResult.ErrorObject is EntryNotFoundException)
+                    throw new ResourceNotFoundException(disableResult.OperationMessage, disableResult.ErrorObject);
+                else if (disableResult.ErrorObject is DataValidationException)
+                    throw new BadRequestException(disableResult.OperationMessage, disableResult.ErrorObject);
+                else
+                    throw new Exception(disableResult.OperationMessage, disableResult.ErrorObject);
+            }
+            else
+                throw new Exception(disableResult.OperationMessage);
+        }
+		//ThrowExceptionForUnsuccessfulOperation($"Failed to disable user account {identifier}.", disableResult);
 
 		Logger.LogInformation("Response body: {@removeResult}", disableResult);
 
@@ -411,31 +392,18 @@ public class DirectoryController : ApiControllerBase<DirectoryController>
 
 		var clientConfig = GetLdapClientConfiguration(serverProfile, IsGlobalCatalog(catalogType));
 
-		string distinguishedName = identifier;
-		if (identifierAttribute == EntryAttribute.sAMAccountName)
-		{
-			var searchResult = await SearchUserAccountAsync(clientConfig, identifier, identifierAttribute.Value, requestLabel);
-
-			if (searchResult.IsSuccessfulOperation)
-			{
-				if (searchResult.Entries.Count() == 0)
-					throw new ResourceNotFoundException($"There is no user account according to the criteria {identifierAttribute} = {identifier}");
-				else
-					distinguishedName = searchResult.Entries.Single().distinguishedName;
-			}
-			else
-				ThrowExceptionForUnsuccessfulOperation($"Failed to disable user account {identifier}.", searchResult);
-		}
-
 		var accountManager = GetAccountManager(clientConfig);
-
-		var removeResult = await accountManager.RemoveUserAccountForMsAD(distinguishedName, requestLabel);
-
+		var removeResult = await accountManager.RemoveMsADUserAccount(identifierAttribute.Value, identifier, requestLabel);
 		if (!removeResult.IsSuccessfulOperation)
 		{
 			if (removeResult.HasErrorObject)
 			{
-				throw removeResult.ErrorObject;
+                if (removeResult.ErrorObject is EntryNotFoundException)
+                    throw new ResourceNotFoundException(removeResult.OperationMessage, removeResult.ErrorObject);
+                else if (removeResult.ErrorObject is DataValidationException)
+                    throw new BadRequestException(removeResult.OperationMessage, removeResult.ErrorObject);
+                else
+                    throw new Exception(removeResult.OperationMessage, removeResult.ErrorObject);
 			}
 			else
 				throw new Exception(removeResult.OperationMessage);
@@ -491,7 +459,16 @@ public class DirectoryController : ApiControllerBase<DirectoryController>
 			{
 				Logger.LogError(searchResult.ErrorObject, "Failed to get LDAP parent entries for user account with {@identifierAttribute}={identifier}", identifierAttribute, identifier);
 
-				throw searchResult.ErrorObject;
+                if (searchResult.ErrorObject is EntryNotFoundException)
+                    throw new ResourceNotFoundException($"{searchResult.OperationMessage} No user entry was found for the specified identifier {identifierAttribute}={identifier}.", searchResult.ErrorObject);
+                else if (searchResult.ErrorObject is LdapException)
+                {
+                    var unwrappedLdapException = (LdapException)searchResult.ErrorObject;
+
+                    throw new LdapException(searchResult.OperationMessage, unwrappedLdapException.ResultCode, unwrappedLdapException.LdapErrorMessage, unwrappedLdapException);
+                }
+                else
+                    throw new Exception(searchResult.OperationMessage, searchResult.ErrorObject);
 			}
 			else
 				throw new Exception(searchResult.OperationMessage);
@@ -678,14 +655,25 @@ public class DirectoryController : ApiControllerBase<DirectoryController>
 
 		if (!searchResult.IsSuccessfulOperation)
 		{
-			if (searchResult.HasErrorObject)
-			{
-				Logger.LogError(searchResult.ErrorObject, "Failed to get LDAP parent entries for user account with {@identifierAttribute}={identifier}", identifierAttribute, identifier);
+            if (searchResult.HasErrorObject)
+            {
+                Logger.LogError(searchResult.ErrorObject, "Failed to get LDAP parent entries for user account with {@identifierAttribute}={identifier}", identifierAttribute, identifier);
 
-				throw searchResult.ErrorObject;
-			}
-			else
-				throw new Exception(searchResult.OperationMessage);
+                if (searchResult.ErrorObject is EntryNotFoundException)
+                    throw new ResourceNotFoundException($"{searchResult.OperationMessage} The group entry with identifier {identifierAttribute}: {identifier} was not found.", searchResult.ErrorObject);
+                else if (searchResult.ErrorObject is LdapException)
+                {
+                    var unwrappedLdapException = (LdapException)searchResult.ErrorObject;
+
+                    throw new LdapException(searchResult.OperationMessage, unwrappedLdapException.ResultCode, unwrappedLdapException.LdapErrorMessage, unwrappedLdapException);
+                }
+                else
+                    throw new Exception(searchResult.OperationMessage, searchResult.ErrorObject);
+            }
+            else
+            {
+                throw new Exception(searchResult.OperationMessage);
+            }
 		}
 
 		Logger.LogInformation("Response body: {@result}", searchResult);

--- a/src/LDAPWebApi/Helpers/StartupHelper.cs
+++ b/src/LDAPWebApi/Helpers/StartupHelper.cs
@@ -378,6 +378,10 @@ public static class StartupHelpers
         var seeder = new MockLdapDataSeeder(logger);
         seeder.SeedAllData();
 
+#if DEBUG
+        seeder.PrintAllData();
+#endif
+
         return app;
     }
 }

--- a/src/LDAPWebApi/Helpers/StartupHelper.cs
+++ b/src/LDAPWebApi/Helpers/StartupHelper.cs
@@ -1,5 +1,7 @@
 using Bitai.LDAPHelper.LdapAdapters;
 using Bitai.LDAPHelper.LdapAdapters.Novell;
+using Bitai.LDAPHelper.Tests.Mocks.LdapAdapters;
+using Bitai.LDAPHelper.Tests.Mocks.LdapData;
 using Bitai.LDAPWebApi.Configurations.App;
 using Bitai.LDAPWebApi.Configurations.LDAP;
 using Bitai.LDAPWebApi.Configurations.Security;
@@ -161,16 +163,25 @@ public static class StartupHelpers
 		return services;
 	}
 
-	internal static IServiceCollection RegisterNovellLdapConnectionFactory(this IServiceCollection services)
+	internal static IServiceCollection RegisterConfiguredLdapConnectionFactory(this IServiceCollection services, WebApiConfiguration webApiConfiguration)
 	{
-		Log.Information("{method}", nameof(RegisterNovellLdapConnectionFactory));
+		Log.Information("{method}", nameof(RegisterConfiguredLdapConnectionFactory));
 
-		services.AddSingleton<ILdapConnectionFactoryAdapter, NovellLdapConnectionFactoryAdapter>();
+        if (webApiConfiguration.TestConfiguration.EnablePersistentMockLdapDataStore)
+        {
+            services.AddSingleton<ILdapConnectionFactoryAdapter, MockLdapPersistentConnectionFactoryAdapter>();
+            Log.Warning("Testing mode is enabled! {method} is registering {mockLdapPersistentConnectionFactoryAdapter} as implementation of {ldapConnectionFactoryAdapterInterface}.", nameof(RegisterConfiguredLdapConnectionFactory), nameof(MockLdapPersistentConnectionFactoryAdapter), nameof(ILdapConnectionFactoryAdapter));
+        }
+        else
+        {            
+            services.AddSingleton<ILdapConnectionFactoryAdapter, NovellLdapConnectionFactoryAdapter>();
+            Log.Information("Testing mode is disabled. {method} is registering {novellLdapConnectionFactoryAdapter} as implementation of {ldapConnectionFactoryAdapterInterface}.", nameof(RegisterConfiguredLdapConnectionFactory), nameof(NovellLdapConnectionFactoryAdapter), nameof(ILdapConnectionFactoryAdapter));
+        }
 
 		return services;
 	}
 
-	internal static IServiceCollection AddAuthenticationWithJwtBearer(this IServiceCollection services, WebApiScopesConfiguration webApiScopesConfiguration, AuthorityConfiguration authorityConfiguration)
+    internal static IServiceCollection AddAuthenticationWithJwtBearer(this IServiceCollection services, WebApiScopesConfiguration webApiScopesConfiguration, AuthorityConfiguration authorityConfiguration)
 	{
 		Log.Information("{method}", nameof(AddAuthenticationWithJwtBearer));
 
@@ -344,4 +355,29 @@ public static class StartupHelpers
 			setupOptions.AddCustomStylesheet("HealthChecksUI.css");
 		});
 	}
+
+    internal static IApplicationBuilder UseMockLdapData(this IApplicationBuilder app, WebApiConfiguration webApiConfiguration)
+    {
+        Log.Information("{method}", nameof(UseMockLdapData));
+
+        if (!webApiConfiguration.TestConfiguration.EnablePersistentMockLdapDataStore)
+        {
+            Log.Information("Test mode is disabled. LDAP test mock data will not be used.");
+
+            return app;
+        }
+        
+        Log.Warning("Test mode is enabled! LDAP test mock data will be used!");
+
+        using var loggerFactory = LoggerFactory.Create(builder => {
+            builder.ClearProviders();
+            builder.AddSerilog(Log.Logger);
+        });
+        var logger = loggerFactory.CreateLogger<MockLdapDataSeeder>();
+
+        var seeder = new MockLdapDataSeeder(logger);
+        seeder.SeedAllData();
+
+        return app;
+    }
 }

--- a/src/LDAPWebApi/Program.cs
+++ b/src/LDAPWebApi/Program.cs
@@ -1,134 +1,159 @@
-using Bitai.LDAPWebApi;
 using Bitai.LDAPWebApi.Configurations.App;
 using Serilog;
-using Serilog.Extensions.Logging;
 using Serilog.Formatting.Compact;
-using Serilog.Formatting.Json;
 using Serilog.Sinks.Elasticsearch;
 using Serilog.Sinks.Grafana.Loki;
-using Serilog.Templates;
 
-var configuration = GetConfiguration(args);
+namespace Bitai.LDAPWebApi;
 
-Log.Logger = SetupLoggerConfiguration(configuration, new LoggerConfiguration(), null, out var webApiConfiguration)
-    .CreateBootstrapLogger();
-
-try
+public class Program
 {
-    Log.Information("Starting {webApiName}", webApiConfiguration.WebApiName);
+    private static IConfiguration _configuration; 
 
-    var webAppBuilder = WebApplication.CreateBuilder(args);
-    webAppBuilder.Host
-        .ConfigureDefaults(args)
-        .UseSerilog((hostBuilderContext, serviceProvider, loggerConfiguration) =>
+    public static void Main(string[] args)
+    {
+        _configuration = GetConfiguration(args);
+
+        Log.Logger = SetupLoggerConfiguration(_configuration, new LoggerConfiguration(), null, out var webApiConfiguration)
+            .CreateBootstrapLogger();
+
+        try
         {
-            SetupLoggerConfiguration(configuration, loggerConfiguration, hostBuilderContext, out webApiConfiguration);
-        });
+            Log.Information("Starting {webApiName}", webApiConfiguration.WebApiName);
 
-    var startup = new Startup(webAppBuilder.Configuration, webAppBuilder.Environment);
+            CreateHostBuilder(args).Build().Run();
 
-    startup.ConfigureServices(webAppBuilder.Services, out webApiConfiguration, out var swaggerUIConfiguration);
-
-    var webApp = webAppBuilder.Build();
-
-    startup.Configure(webApp, webAppBuilder.Environment, webApiConfiguration, swaggerUIConfiguration);
-
-    webApp.Run();
-
-    Log.Warning("Terminating {webApiName}", webApiConfiguration.WebApiName);
-}
-catch (Exception ex)
-{
-    Log.Fatal("Error when creating Host. Below error details.");
-    Log.Fatal("{@error}", ex);
-}
-finally
-{
-    Log.CloseAndFlush();
-}
-
-IConfiguration GetConfiguration(string[] args)
-{
-    var environment = Environment.GetEnvironmentVariable(Startup.ENVARNAME_ASPNETCORE_ENVIRONMENT);
-    var isDevelopment = environment == Environments.Development;
-
-    var configurationBuilder = new ConfigurationBuilder()
-        .SetBasePath(Directory.GetCurrentDirectory())
-        .AddJsonFile("appsettings.json", false, true)
-        .AddJsonFile($"appsettings.{environment}.json", true, true);
-
-    if (isDevelopment)
-    {
-        configurationBuilder.AddUserSecrets<Bitai.LDAPWebApi.Startup>();
+            Log.Warning("Terminating {webApiName}", webApiConfiguration.WebApiName);
+        }
+        catch (Exception ex)
+        {
+            Log.Fatal("Error when creating Host. Below error details.");
+            Log.Fatal("{@error}", ex);
+        }
+        finally
+        {
+            Log.CloseAndFlush();
+        }
     }
 
-    configurationBuilder.AddCommandLine(args);
-    configurationBuilder.AddEnvironmentVariables();
-
-    return configurationBuilder.Build();
-}
-
-LoggerConfiguration SetupLoggerConfiguration(IConfiguration configuration, LoggerConfiguration loggerConfiguration, HostBuilderContext? hostBuilderContext, out WebApiConfiguration webApiConfiguration)
-{
-    webApiConfiguration = configuration.GetSection(nameof(WebApiConfiguration)).Get<WebApiConfiguration>() ?? new WebApiConfiguration();
-
-    var webApiLogConfiguration = configuration.GetSection(nameof(WebApiLogConfiguration)).Get<WebApiLogConfiguration>() ?? new WebApiLogConfiguration();
-
-    //loggerConfiguration = loggerConfiguration
-    //	.MinimumLevel.Override("Microsoft", Serilog.Events.LogEventLevel.Warning);
-
-    //loggerConfiguration = loggerConfiguration
-    //	.Enrich.FromLogContext();
-
-    loggerConfiguration = loggerConfiguration
-        .Enrich.WithProperty("applicationName", webApiConfiguration.WebApiName);
-
-    if (hostBuilderContext != null)
+    private static IConfiguration GetConfiguration(string[] args)
     {
-        loggerConfiguration = loggerConfiguration
-            .Enrich.WithProperty("assemblyName", hostBuilderContext.HostingEnvironment.ApplicationName)
-            .Enrich.WithProperty("environment", hostBuilderContext.HostingEnvironment.EnvironmentName);
+        var environment = Environment.GetEnvironmentVariable(Startup.ENVARNAME_ASPNETCORE_ENVIRONMENT);
+        var isDevelopment = environment == Environments.Development;
+
+        var configurationBuilder = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json", false, true)
+            .AddJsonFile($"appsettings.{environment}.json", true, true);
+
+        if (isDevelopment)
+        {
+            configurationBuilder.AddUserSecrets<Startup>();
+        }
+
+        configurationBuilder.AddCommandLine(args);
+        configurationBuilder.AddEnvironmentVariables();
+
+        return configurationBuilder.Build();
     }
 
-    if (webApiLogConfiguration.ConsoleLog.Enabled)
+    private static LoggerConfiguration SetupLoggerConfiguration(IConfiguration configuration, LoggerConfiguration loggerConfiguration, HostBuilderContext? hostBuilderContext, out WebApiConfiguration webApiConfiguration)
     {
-        var logEventLevel = parseLogEventLevel(webApiLogConfiguration.ConsoleLog.MinimunLogEventLevel);
+        webApiConfiguration = configuration.GetSection(nameof(WebApiConfiguration)).Get<WebApiConfiguration>() ?? new WebApiConfiguration();
+
+        var webApiLogConfiguration = configuration.GetSection(nameof(WebApiLogConfiguration)).Get<WebApiLogConfiguration>() ?? new WebApiLogConfiguration();
+
+        //loggerConfiguration = loggerConfiguration
+        //	.MinimumLevel.Override("Microsoft", Serilog.Events.LogEventLevel.Warning);
+
+        //loggerConfiguration = loggerConfiguration
+        //	.Enrich.FromLogContext();
 
         loggerConfiguration = loggerConfiguration
-            .WriteTo.Console(restrictedToMinimumLevel: logEventLevel, outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}Properties: {Properties}{NewLine}{Exception}");
+            .Enrich.WithProperty("applicationName", webApiConfiguration.WebApiName);
+
+        if (hostBuilderContext != null)
+        {
+            loggerConfiguration = loggerConfiguration
+                .Enrich.WithProperty("assemblyName", hostBuilderContext.HostingEnvironment.ApplicationName)
+                .Enrich.WithProperty("environment", hostBuilderContext.HostingEnvironment.EnvironmentName);
+        }
+
+        if (webApiLogConfiguration.ConsoleLog.Enabled)
+        {
+            var logEventLevel = parseLogEventLevel(webApiLogConfiguration.ConsoleLog.MinimunLogEventLevel);
+
+            loggerConfiguration = loggerConfiguration
+                .WriteTo.Console(restrictedToMinimumLevel: logEventLevel, outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}Properties: {Properties}{NewLine}{Exception}");
+        }
+
+        if (webApiLogConfiguration.FileLog.Enabled)
+        {
+            var logEventLevel = parseLogEventLevel(webApiLogConfiguration.FileLog.MinimunLogEventLevel);
+
+            loggerConfiguration = loggerConfiguration
+                .WriteTo.File(new RenderedCompactJsonFormatter(), webApiLogConfiguration.FileLog.LogFilePath, restrictedToMinimumLevel: logEventLevel, rollingInterval: webApiLogConfiguration.FileLog.RollingInterval, flushToDiskInterval: new TimeSpan(0, webApiLogConfiguration.FileLog.FlushToDiskIntervalInMinutes, 0), retainedFileCountLimit: webApiLogConfiguration.FileLog.RetainedFileCountLimit);
+        }
+
+        if (webApiLogConfiguration.GrafanaLokiLog.Enabled)
+        {
+            var logEventLevel = parseLogEventLevel(webApiLogConfiguration.GrafanaLokiLog.MinimunLogEventLevel);
+
+            loggerConfiguration = loggerConfiguration
+                .WriteTo.GrafanaLoki(webApiLogConfiguration.GrafanaLokiLog.LokiUrl, textFormatter: new RenderedCompactJsonFormatter(), propertiesAsLabels: new string[] { "applicationName", "assemblyName", "environment", "level", "HealthStatus" }, restrictedToMinimumLevel: logEventLevel, batchPostingLimit: webApiLogConfiguration.GrafanaLokiLog.BatchPostingLimit, period: webApiLogConfiguration.GrafanaLokiLog.Period);
+        }
+
+        if (webApiLogConfiguration.ElasticsearchLog.Enabled)
+        {
+            var logEventLevel = parseLogEventLevel(webApiLogConfiguration.ElasticsearchLog.MinimunLogEventLevel);
+
+            loggerConfiguration = loggerConfiguration
+                .WriteTo.Elasticsearch(new ElasticsearchSinkOptions(webApiLogConfiguration.ElasticsearchLog.GetElasticsearchNodeUris())
+                {
+                    AutoRegisterTemplate = true,
+                });
+        }
+
+        return loggerConfiguration;
+
+        Serilog.Events.LogEventLevel parseLogEventLevel(WebApiLogConfiguration.MinimunLogEventLevel minimunLogEventLevel)
+        {
+            return minimunLogEventLevel == WebApiLogConfiguration.MinimunLogEventLevel.Verbose ? Serilog.Events.LogEventLevel.Verbose : (minimunLogEventLevel == WebApiLogConfiguration.MinimunLogEventLevel.Debug ? Serilog.Events.LogEventLevel.Debug : (minimunLogEventLevel == WebApiLogConfiguration.MinimunLogEventLevel.Information ? Serilog.Events.LogEventLevel.Information : (minimunLogEventLevel == WebApiLogConfiguration.MinimunLogEventLevel.Warning ? Serilog.Events.LogEventLevel.Warning : (minimunLogEventLevel == WebApiLogConfiguration.MinimunLogEventLevel.Error ? Serilog.Events.LogEventLevel.Error : (minimunLogEventLevel == WebApiLogConfiguration.MinimunLogEventLevel.Fatal ? Serilog.Events.LogEventLevel.Fatal : throw new Exception("Invalid Web Api application log level. Verify web api _configuration."))))));
+        }
     }
 
-    if (webApiLogConfiguration.FileLog.Enabled)
-    {
-        var logEventLevel = parseLogEventLevel(webApiLogConfiguration.FileLog.MinimunLogEventLevel);
+    public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                 .ConfigureAppConfiguration((hostContext, configApp) =>
+                 {
+                     var configurationRoot = configApp.Build();
 
-        loggerConfiguration = loggerConfiguration
-            .WriteTo.File(new RenderedCompactJsonFormatter(), webApiLogConfiguration.FileLog.LogFilePath, restrictedToMinimumLevel: logEventLevel, rollingInterval: webApiLogConfiguration.FileLog.RollingInterval, flushToDiskInterval: new TimeSpan(0, webApiLogConfiguration.FileLog.FlushToDiskIntervalInMinutes, 0), retainedFileCountLimit: webApiLogConfiguration.FileLog.RetainedFileCountLimit);
-    }
+                     //// BITAI: Remains for future implementation.
+                     //configApp.AddJsonFile("serilog.json", optional: true, reloadOnChange: true);
 
-    if (webApiLogConfiguration.GrafanaLokiLog.Enabled)
-    {
-        var logEventLevel = parseLogEventLevel(webApiLogConfiguration.GrafanaLokiLog.MinimunLogEventLevel);
+                     var env = hostContext.HostingEnvironment;
 
-        loggerConfiguration = loggerConfiguration
-            .WriteTo.GrafanaLoki(webApiLogConfiguration.GrafanaLokiLog.LokiUrl, textFormatter: new RenderedCompactJsonFormatter(), propertiesAsLabels: new string[] { "applicationName", "assemblyName", "environment", "level", "HealthStatus" }, restrictedToMinimumLevel: logEventLevel, batchPostingLimit: webApiLogConfiguration.GrafanaLokiLog.BatchPostingLimit, period: webApiLogConfiguration.GrafanaLokiLog.Period);
-    }
+                     //// BITAI: Remains for future implementation.
+                     //configApp.AddJsonFile($"serilog.{env.EnvironmentName}.json", optional: true, reloadOnChange: true);
 
-    if (webApiLogConfiguration.ElasticsearchLog.Enabled)
-    {
-        var logEventLevel = parseLogEventLevel(webApiLogConfiguration.ElasticsearchLog.MinimunLogEventLevel);
+                     if (env.IsDevelopment())
+                     {
+                         configApp.AddUserSecrets<Startup>(true);
+                     }
 
-        loggerConfiguration = loggerConfiguration
-            .WriteTo.Elasticsearch(new ElasticsearchSinkOptions(webApiLogConfiguration.ElasticsearchLog.GetElasticsearchNodeUris())
-            {
-                AutoRegisterTemplate = true,
-            });
-    }
+                     //// BITAI: Remains for future implementation.
+                     //configurationRoot.AddAzureKeyVaultConfiguration(configApp);
 
-    return loggerConfiguration;
-
-    Serilog.Events.LogEventLevel parseLogEventLevel(WebApiLogConfiguration.MinimunLogEventLevel minimunLogEventLevel)
-    {
-        return minimunLogEventLevel == WebApiLogConfiguration.MinimunLogEventLevel.Verbose ? Serilog.Events.LogEventLevel.Verbose : (minimunLogEventLevel == WebApiLogConfiguration.MinimunLogEventLevel.Debug ? Serilog.Events.LogEventLevel.Debug : (minimunLogEventLevel == WebApiLogConfiguration.MinimunLogEventLevel.Information ? Serilog.Events.LogEventLevel.Information : (minimunLogEventLevel == WebApiLogConfiguration.MinimunLogEventLevel.Warning ? Serilog.Events.LogEventLevel.Warning : (minimunLogEventLevel == WebApiLogConfiguration.MinimunLogEventLevel.Error ? Serilog.Events.LogEventLevel.Error : (minimunLogEventLevel == WebApiLogConfiguration.MinimunLogEventLevel.Fatal ? Serilog.Events.LogEventLevel.Fatal : throw new Exception("Invalid Web Api application log level. Verify web api configuration."))))));
-    }
+                     configApp.AddEnvironmentVariables();
+                     configApp.AddCommandLine(args);
+                 })
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.ConfigureKestrel(options => options.AddServerHeader = true);
+                    webBuilder.UseStartup<Startup>();
+                })
+                .UseSerilog((hostContext, loggerConfig) =>
+                {
+                    SetupLoggerConfiguration(hostContext.Configuration, loggerConfig, hostContext, out _);
+                });
 }

--- a/src/LDAPWebApi/Startup.cs
+++ b/src/LDAPWebApi/Startup.cs
@@ -1,13 +1,4 @@
-using Bitai.LDAPHelper.LdapAdapters;
-using Bitai.LDAPHelper.LdapAdapters.Novell;
 using Bitai.LDAPWebApi.Helpers;
-using HealthChecks.UI.Client;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Diagnostics.HealthChecks;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Serilog;
 
 namespace Bitai.LDAPWebApi;
@@ -17,10 +8,13 @@ namespace Bitai.LDAPWebApi;
 /// </summary>
 public class Startup
 {
-	/// <summary>
-	/// Environment variable name for ASPNETCORE_ENVIRONMENT
-	/// </summary>
-	public const string ENVARNAME_ASPNETCORE_ENVIRONMENT = "ASPNETCORE_ENVIRONMENT";
+    private Configurations.App.WebApiConfiguration _webApiConfiguration;
+    private Configurations.Swagger.SwaggerUIConfiguration _swaggerUIConfiguration;
+
+    /// <summary>
+    /// Environment variable name for ASPNETCORE_ENVIRONMENT
+    /// </summary>
+    public const string ENVARNAME_ASPNETCORE_ENVIRONMENT = "ASPNETCORE_ENVIRONMENT";
 
 
 
@@ -54,18 +48,18 @@ public class Startup
 
 
 
-	/// <summary>
-	/// This method gets called by the runtime. 
-	/// Use this method to add services to the container.
-	/// </summary>
-	/// <param name="services">Injected <see cref="IServiceCollection"/></param>
-	/// <param name="webApiConfiguration">Return the configuration of the Web API application. See <see cref="Configurations.App.WebApiConfiguration"/>.</param>
-	/// <param name="swaggerUIConfiguration">See <see cref="Configurations.Swagger.SwaggerUIConfiguration"/></param>
-	public void ConfigureServices(IServiceCollection services, out Configurations.App.WebApiConfiguration webApiConfiguration, out Configurations.Swagger.SwaggerUIConfiguration swaggerUIConfiguration)
-	{
+    /// <summary>
+    /// This method gets called by the runtime. 
+    /// Use this method to add services to the container.
+    /// </summary>
+    /// <param name="services">Injected <see cref="IServiceCollection"/></param>
+    /// <param name="webApiConfiguration">Return the _configuration of the Web API application. See <see cref="Configurations.App.WebApiConfiguration"/>.</param>
+    /// <param name="swaggerUIConfiguration">See <see cref="Configurations.Swagger.SwaggerUIConfiguration"/></param>
+    public void ConfigureServices(IServiceCollection services)    
+    {
 		Log.Information("{class} -> {method} starting...", FullName, nameof(ConfigureServices));
 
-		services.AddWebApiConfiguration(Configuration, out webApiConfiguration);
+		services.AddWebApiConfiguration(Configuration, out _webApiConfiguration);
 
 		services.AddWebApiLogConfiguration(Configuration);
 
@@ -77,7 +71,7 @@ public class Startup
 
 		services.RegisterRouteConstraints();
 
-		services.RegisterConfiguredLdapConnectionFactory(webApiConfiguration);
+		services.RegisterConfiguredLdapConnectionFactory(_webApiConfiguration);
 
 		services.AddControllers();
 
@@ -87,25 +81,25 @@ public class Startup
 
 		services.AddAuthorizationWithApiScopePolicies(webApiScopesConfiguration, authorityConfiguration);
 
-		services.AddCustomHealthChecks(webApiConfiguration, authorityConfiguration, webApiScopesConfiguration, ldapServerProfiles);
+		services.AddCustomHealthChecks(_webApiConfiguration, authorityConfiguration, webApiScopesConfiguration, ldapServerProfiles);
 
-		services.AddSwaggerConfiguration(Configuration, out swaggerUIConfiguration);
+		services.AddSwaggerConfiguration(Configuration, out _swaggerUIConfiguration);
 
-		services.ConfigureSwaggerGenerator(webApiConfiguration, webApiScopesConfiguration, authorityConfiguration, swaggerUIConfiguration);
+		services.ConfigureSwaggerGenerator(_webApiConfiguration, webApiScopesConfiguration, authorityConfiguration, _swaggerUIConfiguration);
 
 		Log.Information("{class} -> {method} completed.", FullName, nameof(ConfigureServices));
 	}
 
-	/// <summary>
-	/// This method gets called by the runtime. 
-	/// Use this method to configure the HTTP request pipeline.
-	/// </summary>
-	/// <param name="app">Injected <see cref="IApplicationBuilder"/></param>
-	/// <param name="env">Injected <see cref="IWebHostEnvironment"/></param>
-	/// <param name="webApiConfiguration">Injected <see cref="Configurations.App.WebApiConfiguration"/></param>
-	/// <param name="swaggerUIConfiguration">Injected <see cref="Configurations.Swagger.SwaggerUIConfiguration"/></param>
-	public void Configure(IApplicationBuilder app, IWebHostEnvironment env, Configurations.App.WebApiConfiguration webApiConfiguration, Configurations.Swagger.SwaggerUIConfiguration swaggerUIConfiguration)
-	{
+    /// <summary>
+    /// This method gets called by the runtime. 
+    /// Use this method to configure the HTTP request pipeline.
+    /// </summary>
+    /// <param name="app">Injected <see cref="IApplicationBuilder"/></param>
+    /// <param name="env">Injected <see cref="IWebHostEnvironment"/></param>
+    /// <param name="webApiConfiguration">Injected <see cref="Configurations.App.WebApiConfiguration"/></param>
+    /// <param name="swaggerUIConfiguration">Injected <see cref="Configurations.Swagger.SwaggerUIConfiguration"/></param>
+    public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+    {
 		if (env.IsDevelopment())
 		{
 			app.UseDeveloperExceptionPage();
@@ -157,15 +151,15 @@ public class Startup
 
 		app.UseEndpoints(endpoints =>
 		{
-			endpoints.MapCustomHealthChecks(webApiConfiguration);
+			endpoints.MapCustomHealthChecks(_webApiConfiguration);
 
 			endpoints.MapControllers();
 		});
 
 		app.UseSwagger();
 
-		app.UseSwaggerUI(webApiConfiguration, swaggerUIConfiguration);
+		app.UseSwaggerUI(_webApiConfiguration, _swaggerUIConfiguration);
 
-        app.UseMockLdapData(webApiConfiguration);
+        app.UseMockLdapData(_webApiConfiguration);
 	}
 }

--- a/src/LDAPWebApi/Startup.cs
+++ b/src/LDAPWebApi/Startup.cs
@@ -77,7 +77,7 @@ public class Startup
 
 		services.RegisterRouteConstraints();
 
-		services.RegisterNovellLdapConnectionFactory();
+		services.RegisterConfiguredLdapConnectionFactory(webApiConfiguration);
 
 		services.AddControllers();
 
@@ -165,5 +165,7 @@ public class Startup
 		app.UseSwagger();
 
 		app.UseSwaggerUI(webApiConfiguration, swaggerUIConfiguration);
+
+        app.UseMockLdapData(webApiConfiguration);
 	}
 }

--- a/src/LDAPWebApi/appsettings.full.example.json
+++ b/src/LDAPWebApi/appsettings.full.example.json
@@ -17,7 +17,10 @@
 			"UIPath": "hc-ui",
 			"MaximunHistoryEntries": 200,
 			"EvaluationTime": 180
-		}
+		},
+        "TestConfiguration": {
+            "EnablePersistentMockLdapDataStore": false
+        }
 	},
 	"WebApiCorsConfiguration": {
 		"AllowAnyOrigin": false,

--- a/src/LDAPWebApi/appsettings.json
+++ b/src/LDAPWebApi/appsettings.json
@@ -1,14 +1,17 @@
 {
     "AllowedHosts": "*",
     "WebApiConfiguration": {
-        "HealthChecksConfiguration": {
-            "EnableHealthChecks": false,
-            "WebApiBaseUrl": "https://localhost",
-            "EvaluationTime": 60
-        }
+      "HealthChecksConfiguration": {
+        "EnableHealthChecks": false,
+        "WebApiBaseUrl": "https://localhost:5101",
+        "EvaluationTime": 60
+      },
+      "TestConfiguration": {
+        "EnablePersistentMockLdapDataStore": false
+      }
     },
     "WebApiCorsConfiguration": {
-        "AllowAnyOrigin": true,
+        "AllowAnyOrigin": false,
         "AllowedOrigins": []
     },
     "WebApiLogConfiguration": {
@@ -52,21 +55,6 @@
             "HealthCheckPingTimeout": 10
         },
         {
-            "ProfileId": "EDU2",
-            "Server": "192.168.7.3",
-            "Port": "Default",
-            "UseSSL": "true",
-            "BaseDN": "DC=grupo2,DC=edu",
-            "PortForGlobalCatalog": "Default",
-            "UseSSLforGlobalCatalog": "false",
-            "BaseDNforGlobalCatalog": "DC=grupo2,DC=edu",
-            "DefaultDomainName": "EDU2",
-            "ConnectionTimeout": "10",
-            "DomainUserAccount": "EDU2\\accountName",
-            "DomainAccountPassword": "p@$$w0rd",
-            "HealthCheckPingTimeout": 10
-        },
-        {
             "ProfileId": "AIRPE",
             "Server": "10.11.58.13",
             "Port": "Default",
@@ -81,5 +69,22 @@
             "DomainAccountPassword": "p@$$w0rd",
             "HealthCheckPingTimeout": 10
         }
-    ]
+    ],
+    "SwaggerUIConfiguration": {
+      "SwaggerUIClientId": "Bitai.LdapWebApi.Dev.Swagger.Client",
+      "SwaggerUITargetApiScopes": [
+        {
+          "SwaggerUITargetApiScopeName": "Bitai.LdapWebApi.Dev.ApiScope.Reader",
+          "SwaggerUITargetApiScopeTitle": "BITAI LDAP Web Api Reader Scope"
+        },
+        {
+          "SwaggerUITargetApiScopeName": "Bitai.LdapWebApi.Dev.ApiScope.Admin",
+          "SwaggerUITargetApiScopeTitle": "BITAI LDAP Web Api Admin Scope"
+        },
+        {
+          "SwaggerUITargetApiScopeName": "Bitai.LdapWebApi.Dev.ApiScope.Dummy",
+          "SwaggerUITargetApiScopeTitle": "BITAI LDAP Web Api Dummy Scope"
+        }
+      ]
+    }
 }

--- a/tests/Bitai.LDAPWebApi.Tests/Bitai.LDAPWebApi.Tests.csproj
+++ b/tests/Bitai.LDAPWebApi.Tests/Bitai.LDAPWebApi.Tests.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Version>10.0.0</Version>
+    <Authors>Victor Bastidas (BITAI)</Authors>
+    <Company>BITAI</Company>
+    <Product>BITAI LDAP Web Api</Product>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\LDAPWebApi\Bitai.LDAPWebApi.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.Tests.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/tests/Bitai.LDAPWebApi.Tests/Controllers/AuthenticationsControllerTests.cs
+++ b/tests/Bitai.LDAPWebApi.Tests/Controllers/AuthenticationsControllerTests.cs
@@ -1,0 +1,284 @@
+using System.Net;
+using System.Net.Http.Json;
+using Bitai.LDAPHelper.DTO;
+using Bitai.LDAPWebApi.Tests.Infrastructure;
+
+namespace Bitai.LDAPWebApi.Tests.Controllers;
+
+/// <summary>
+/// Integration tests for <see cref="Bitai.LDAPWebApi.Controllers.AuthenticationsController"/>.
+///
+/// These tests rely on the application's built-in mock LDAP data store 
+/// (<c>EnablePersistentMockLdapDataStore = true</c>).  The <see cref="LDAPWebApiFactory"/>
+/// starts the full ASP.NET Core pipeline with <see cref="Bitai.LDAPWebApi.Startup"/> and
+/// authorization bypass enabled, so every request is treated as authenticated.
+///
+/// Route template:
+///   POST  api/{serverProfile:ldapSvrPf}/{catalogType:ldapCatType}/Authentications/authenticate
+///
+/// Mock data used (from MockLdapDataSeeder):
+///   • Server profile  : HOLDING  (BaseDN = DC=holding,DC=latam,DC=com)
+///   • Catalog type    : LC  (local catalog)
+///   • Valid user      : james.dockers  /  Domain: HOLDING
+///   • Disabled user   : sara.pikes@US (userAccountControl = 514)
+/// </summary>
+[Collection("LDAPWebApi Integration Tests")]
+public class AuthenticationsControllerTests : IClassFixture<LDAPWebApiFactory>
+{
+    private readonly HttpClient _client;
+
+    private const string ServerProfile = "HOLDING";
+    private const string LocalCatalog = "LC";
+
+
+
+
+    public AuthenticationsControllerTests(LDAPWebApiFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+
+
+
+    #region Private methods
+    private static string AuthenticateUrl(string serverProfile, string catalogType, string? requestLabel = null)
+    {        
+        return AuthenticateBaseUrl(serverProfile, catalogType, "authenticate", requestLabel);
+    }
+
+    private static string AuthenticateWithoutUserLookupUrl(string serverProfile, string catalogType, string? requestLabel = null)
+    {
+        return AuthenticateBaseUrl(serverProfile, catalogType, "authenticateWithoutUserLookup", requestLabel);
+    }
+
+    private static string AuthenticateBaseUrl(string serverProfile, string catalogType, string authenticateAction, string? requestLabel = null)
+    {
+        var url = $"api/{serverProfile}/{catalogType}/Authentications/{authenticateAction}";
+
+        if (!string.IsNullOrEmpty(requestLabel))
+            url += $"?requestLabel={Uri.EscapeDataString(requestLabel)}";
+
+        return url;
+    }
+    #endregion
+
+    #region Success scenarios
+    /// <summary>
+    /// A valid credential for a known user in the mock store should return 200 OK
+    /// with <see cref="LDAPDomainAccountAuthenticationResult.IsSuccessfulOperation"/> = true
+    /// and <see cref="LDAPDomainAccountAuthenticationResult.IsAuthenticated"/> = true.
+    /// </summary>
+    [Fact]
+    public async Task AuthenticateAsync_ValidCredential_ReturnsOkAndAuthenticated()
+    {
+        // Arrange
+        var credential = new LDAPDomainAccountCredential(
+            domainName: "HOLDING",
+            username: "james.dockers",
+            domainAccountPassword: "AnyPassword#1"  // mock adapter accepts any password for valid users
+        );
+        var url = AuthenticateUrl(ServerProfile, LocalCatalog, "test-auth-valid");
+
+        // Act
+        var response = await _client.PostAsJsonAsync(url, credential);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<LDAPDomainAccountAuthenticationResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation, "Operation should be marked successful.");
+        Assert.True(result.IsAuthenticated, "Account should be authenticated.");
+    }
+
+    /// <summary>
+    /// When the <c>DomainName</c> property is empty the controller should fall back to
+    /// the server profile's <c>DefaultDomainName</c> (HOLDING).  The result is still OK.
+    /// </summary>
+    [Fact]
+    public async Task AuthenticateAsync_CredentialWithoutDomainName_UsesProfileDefaultDomainAndReturnsOk()
+    {
+        // Arrange: omit domain name; expect the API to fill it from the server profile
+        var credential = new LDAPDomainAccountCredential() {
+            AccountName = "isaac.newton",
+            DomainAccountPassword = "AnyPassword#1"
+        };
+
+        var url = AuthenticateUrl(ServerProfile, LocalCatalog);
+
+        // Act
+        var response = await _client.PostAsJsonAsync(url, credential);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<LDAPDomainAccountAuthenticationResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+        Assert.True(result.IsAuthenticated);
+    }
+
+    /// <summary>
+    /// Authentication request with an optional <c>requestLabel</c> query parameter should
+    /// propagate the label into the returned result.
+    /// </summary>
+    [Fact]
+    public async Task AuthenticateAsync_WithRequestLabel_ResultContainsRequestLabel()
+    {
+        // Arrange
+        const string label = "unit-test-label-001";
+        var credential = new LDAPDomainAccountCredential("HOLDING", "manuel.cordoba", "AnyPassword#1");
+        var url = AuthenticateUrl(ServerProfile, LocalCatalog, label);
+
+        // Act
+        var response = await _client.PostAsJsonAsync(url, credential);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<LDAPDomainAccountAuthenticationResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+        Assert.Equal(label, result.RequestLabel);
+    }
+
+    /// <summary>
+    /// A valid credential for a known user in the mock store should return 200 OK
+    /// with <see cref="LDAPDomainAccountAuthenticationResult.IsSuccessfulOperation"/> = true
+    /// and <see cref="LDAPDomainAccountAuthenticationResult.IsAuthenticated"/> = true.
+    /// </summary>
+    [Fact]
+    public async Task AuthenticateWithoutUserLookupAsync_ValidCredential_ReturnsOkAndAuthenticated()
+    {
+        // Arrange
+        var credential = new LDAPDomainAccountCredential(
+            domainName: "HOLDING",
+            username: "james.dockers",
+            domainAccountPassword: "AnyPassword#1"  // mock adapter accepts any password for valid users
+        );
+        var url = AuthenticateWithoutUserLookupUrl(ServerProfile, LocalCatalog, "test-auth-valid");
+
+        // Act
+        var response = await _client.PostAsJsonAsync(url, credential);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<LDAPDomainAccountAuthenticationResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation, "Operation should be marked successful.");
+        Assert.True(result.IsAuthenticated, "Account should be authenticated.");
+    }
+    #endregion
+
+    #region Failure scenarios
+    /// <summary>
+    /// A credential for a user that does not exist in the mock store should return a
+    /// response where <see cref="LDAPDomainAccountAuthenticationResult.IsAuthenticated"/>
+    /// is <c>false</c> (or throw, depending on the mock adapter behavior).
+    /// We assert a non-2xx response OR a successful response with authentication = false.
+    /// </summary>
+    [Fact]
+    public async Task AuthenticateAsync_NonExistentUser_ReturnsNotAuthenticated()
+    {
+        // Arrange
+        var credential = new LDAPDomainAccountCredential("HOLDING", "nobody.here", "AnyPassword#1");
+        var url = AuthenticateUrl(ServerProfile, LocalCatalog);
+
+        // Act
+        var response = await _client.PostAsJsonAsync(url, credential);
+
+        // Assert: the mock adapter should return authentication = false (or 500/4xx on error)
+        if (response.IsSuccessStatusCode)
+        {
+            var result = await response.Content.ReadFromJsonAsync<LDAPDomainAccountAuthenticationResult>();
+            Assert.NotNull(result);
+            Assert.False(result.IsAuthenticated, "Unknown user should not be authenticated.");
+        }
+        else
+        {
+            // Any non-success HTTP status is also acceptable for a non-existent user
+            Assert.True((int)response.StatusCode >= 400,
+                $"Expected 4xx/5xx for non-existent user, got {(int)response.StatusCode}.");
+        }
+    }
+
+    /// <summary>
+    /// Sending an empty body (no credential) should return 400 Bad Request because the
+    /// <c>[FromBody]</c> model binding will fail.
+    /// </summary>
+    [Fact]
+    public async Task AuthenticateAsync_NullBody_ReturnsBadRequest()
+    {
+        // Arrange
+        var url = AuthenticateUrl(ServerProfile, LocalCatalog);
+        var content = new StringContent("null", System.Text.Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await _client.PostAsync(url, content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    /// <summary>
+    /// An unknown server profile in the route should be rejected by the
+    /// <c>ldapSvrPf</c> route constraint (returns 404).
+    /// </summary>
+    [Fact]
+    public async Task AuthenticateAsync_UnknownServerProfile_ReturnsNotFound()
+    {
+        // Arrange
+        var credential = new LDAPDomainAccountCredential("HOLDING", "james.dockers", "AnyPassword#1");
+        var url = AuthenticateUrl("UNKNOWN_PROFILE", LocalCatalog);
+
+        // Act
+        var response = await _client.PostAsJsonAsync(url, credential);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    /// <summary>
+    /// An invalid catalog type in the route should be rejected by the
+    /// <c>ldapCatType</c> route constraint (returns 404).
+    /// </summary>
+    [Fact]
+    public async Task AuthenticateAsync_InvalidCatalogType_ReturnsNotFound()
+    {
+        // Arrange
+        var credential = new LDAPDomainAccountCredential("HOLDING", "james.dockers", "AnyPassword#1");
+        var url = AuthenticateUrl(ServerProfile, "INVALID_CATALOG");
+
+        // Act
+        var response = await _client.PostAsJsonAsync(url, credential);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Authentication against the Global Catalog catalog type should work the same way
+    /// as against the local catalog for a valid user.
+    /// </summary>
+    [Fact]
+    public async Task AuthenticateAsync_UsingGlobalCatalog_ValidCredential_ReturnsOk()
+    {
+        // Arrange
+        var credential = new LDAPDomainAccountCredential("HOLDING", "james.dockers", "AnyPassword#1");
+        var url = AuthenticateUrl(ServerProfile, "GC");
+
+        // Act
+        var response = await _client.PostAsJsonAsync(url, credential);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<LDAPDomainAccountAuthenticationResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+        Assert.True(result.IsAuthenticated);
+    }
+    #endregion
+}

--- a/tests/Bitai.LDAPWebApi.Tests/Controllers/DirectoryControllerTests.cs
+++ b/tests/Bitai.LDAPWebApi.Tests/Controllers/DirectoryControllerTests.cs
@@ -1,0 +1,886 @@
+using System.Net;
+using System.Net.Http.Json;
+using Bitai.LDAPHelper.DTO;
+using Bitai.LDAPWebApi.DTO;
+using Bitai.LDAPWebApi.Tests.Infrastructure;
+
+namespace Bitai.LDAPWebApi.Tests.Controllers;
+
+/// <summary>
+/// Integration tests for <see cref="Bitai.LDAPWebApi.Controllers.DirectoryController"/>.
+///
+/// The tests use the built-in mock LDAP data store activated via
+/// <c>EnablePersistentMockLdapDataStore = true</c>.  The <see cref="LDAPWebApiFactory"/>
+/// starts the full ASP.NET Core pipeline with authorization bypassed.
+///
+/// Mock data snapshot (from <c>MockLdapDataSeeder.SeedAllData()</c>):
+///   • Server profile  : HOLDING  (BaseDN = DC=holding,DC=latam,DC=com)
+///   • Catalog types   : LC (local) | GC (global)
+///   • Users with sAMAccountName:
+///       james.dockers, sara.pikes, robert.miller, isaac.newton, manuel.cordoba,
+///       saint.seiya, ken.master, victor.bastidas, red.robbin, alice.wonder
+///   • Groups with sAMAccountName:
+///       DomainAdmins, ITAdmins, DevOpsEng, SeniorDevOps, JuniorDevOps,
+///       Interns, SupportTeam, Administrators, SecurityAnalysts, DevOpsLeaders
+/// </summary>
+[Collection("LDAPWebApi Integration Tests")]
+public class DirectoryControllerTests : IClassFixture<LDAPWebApiFactory>
+{
+    private readonly HttpClient _client;
+
+    private const string ServerProfile = "HOLDING";
+    private const string LC = "LC";   // local catalog
+    private const string GC = "GC";   // global catalog
+
+    public DirectoryControllerTests(LDAPWebApiFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+
+
+
+    #region GET …/Directory/{identifier}   (GetByIdentifier)
+    /// <summary>
+    /// Retrieve a known user by sAMAccountName.  Default identifier attribute is sAMAccountName.
+    /// </summary>
+    [Fact]
+    public async Task GetByIdentifier_ExistingUser_BySAMAccountName_ReturnsOkWithEntry()
+    {
+        // Arrange
+        var url = $"api/{ServerProfile}/{LC}/Directory/james.dockers?identifierAttribute={EntryAttribute.sAMAccountName}";
+
+        // Act
+        var response = await _client.GetAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<LDAPSearchResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+        Assert.Single(result.Entries);
+        Assert.Equal("james.dockers",
+            result.Entries.First().samAccountName,
+            ignoreCase: true);
+    }
+
+    /// <summary>
+    /// Retrieve a known user by distinguishedName.
+    /// </summary>
+    [Fact]
+    public async Task GetByIdentifier_ExistingUser_ByDistinguishedName_ReturnsOkWithEntry()
+    {
+        // Arrange – james.dockers is in OU=Seniors,OU=DevOps,OU=IT,DC=holding,DC=latam,DC=com
+        const string dn = "CN=James Dockers,OU=Seniors,OU=DevOps,OU=IT,DC=holding,DC=latam,DC=com";
+        var url = $"api/{ServerProfile}/{LC}/Directory/{Uri.EscapeDataString(dn)}?identifierAttribute={EntryAttribute.distinguishedName}";
+
+        // Act
+        var response = await _client.GetAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<LDAPSearchResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+        Assert.Single(result.Entries);
+        Assert.Equal(dn, result.Entries.First().distinguishedName, ignoreCase: true);
+    }
+
+    /// <summary>
+    /// A sAMAccountName that does not exist should return 404 Not Found.
+    /// </summary>
+    [Fact]
+    public async Task GetByIdentifier_NonExistentUser_ReturnsNotFound()
+    {
+        // Arrange
+        var url = $"api/{ServerProfile}/{LC}/Directory/ghost.user?identifierAttribute={EntryAttribute.sAMAccountName}";
+
+        // Act
+        var response = await _client.GetAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+    #endregion
+
+    #region GET …/Directory/filterBy   (FilterByAsync)
+    /// <summary>
+    /// Filter entries by a single attribute – here <c>sAMAccountName=james.dockers</c>.
+    /// </summary>
+    [Fact]
+    public async Task FilterBy_SingleFilter_MatchingUser_ReturnsOkWithEntries()
+    {
+        // Arrange
+        var url = $"api/{ServerProfile}/{LC}/Directory/filterBy" +
+                  $"?filterAttribute={EntryAttribute.sAMAccountName}&filterValue=james.dockers&requiredAttributes={RequiredEntryAttributes.Minimun}";
+
+        // Act
+        var response = await _client.GetAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<LDAPSearchResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+        Assert.NotEmpty(result.Entries);
+        Assert.All(result.Entries, e =>
+            Assert.Equal("james.dockers", e.samAccountName, ignoreCase: true));
+    }
+
+    /// <summary>
+    /// Filter entries by a wildcard – <c>sAMAccountName=*.dockers*</c> should find james.dockers.
+    /// </summary>
+    [Fact]
+    public async Task FilterBy_WildcardFilter_ReturnsMatchingEntries()
+    {
+        // Arrange
+        var url = $"api/{ServerProfile}/{LC}/Directory/filterBy" +
+                  $"?filterAttribute={EntryAttribute.sAMAccountName}&filterValue=*dockers*&requiredAttributes={RequiredEntryAttributes.Minimun}";
+
+        // Act
+        var response = await _client.GetAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<LDAPSearchResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+        Assert.NotEmpty(result.Entries);
+    }
+
+    /// <summary>
+    /// Filter with two attribute filters combined with AND (combineFilters=true).
+    /// Searching for sAMAccountName=james.dockers AND givenName=James should return one entry.
+    /// </summary>
+    [Fact]
+    public async Task FilterBy_TwoFiltersAndCombined_ReturnsMatchingEntry()
+    {
+        // Arrange
+        var url = $"api/{ServerProfile}/{LC}/Directory/filterBy" +
+                  $"?filterAttribute={EntryAttribute.sAMAccountName}&filterValue=james.dockers" +
+                  $"&secondFilterAttribute=givenName&secondFilterValue=James" +
+                  $"&combineFilters=true&requiredAttributes={RequiredEntryAttributes.Minimun}";
+
+        // Act
+        var response = await _client.GetAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<LDAPSearchResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+        Assert.NotEmpty(result.Entries);
+    }
+
+    /// <summary>
+    /// Filter with two attribute filters combined with OR (combineFilters=false).
+    /// Searching for sAMAccountName=james.dockers OR sAMAccountName=isaac.newton
+    /// should return at least two entries.
+    /// </summary>
+    [Fact]
+    public async Task FilterBy_TwoFiltersOrCombined_ReturnsBothEntries()
+    {
+        // Arrange
+        var url = $"api/{ServerProfile}/{LC}/Directory/filterBy" +
+                  $"?filterAttribute={EntryAttribute.sAMAccountName}&filterValue=james.dockers" +
+                  $"&secondFilterAttribute={EntryAttribute.sAMAccountName}&secondFilterValue=isaac.newton" +
+                  $"&combineFilters=false&requiredAttributes={RequiredEntryAttributes.Minimun}";
+
+        // Act
+        var response = await _client.GetAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<LDAPSearchResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+        Assert.True(result.Entries.Count() > 0, "OR filter should return at least 1 entries.");
+    }
+
+    /// <summary>
+    /// A filter that matches no entries should still return 200 OK with an empty
+    /// entries collection (not a 404).
+    /// </summary>
+    [Fact]
+    public async Task FilterBy_NoMatch_ReturnsOkWithEmptyEntries()
+    {
+        // Arrange
+        var url = $"api/{ServerProfile}/{LC}/Directory/filterBy" +
+                  $"?filterAttribute={EntryAttribute.sAMAccountName}&filterValue=GhostUser&requiredAttributes={RequiredEntryAttributes.Minimun}";
+
+        // Act
+        var response = await _client.GetAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<LDAPSearchResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+        Assert.Empty(result.Entries);
+    }
+    #endregion
+
+    #region GET …/Directory/Users/filterBy   (GetUsersFilteringByAsync)
+    /// <summary>
+    /// Without any filters the endpoint should return only user entries (not groups).
+    /// </summary>
+    [Fact]
+    public async Task GetUsersFilteringBy_WithSingleFilter_ReturnsOnlyUserEntries()
+    {
+        // Arrange – search for users with sAMAccountName containing "dockers"
+        var url = $"api/{ServerProfile}/{LC}/Directory/Users/filterBy" +
+                  $"?filterAttribute={EntryAttribute.sAMAccountName}&filterValue=*dockers*&requiredAttributes={RequiredEntryAttributes.Few}";
+
+        // Act
+        var response = await _client.GetAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<LDAPSearchResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+        Assert.NotEmpty(result.Entries);
+        // All returned entries must be user objects (they contain "user" objectClass)
+        // – we verify by checking that sAMAccountName is populated (groups have it too
+        //   but the endpoint filters by user objectClass internally)
+        Assert.All(result.Entries, e => Assert.False(string.IsNullOrEmpty(e.samAccountName)));
+    }
+
+    /// <summary>
+    /// A dual-attribute AND-combined user filter: sAMAccountName=james.dockers AND givenName=James.
+    /// </summary>
+    [Fact]
+    public async Task GetUsersFilteringBy_TwoFiltersAnd_ReturnsMatchingUsers()
+    {
+        // Arrange
+        var url = $"api/{ServerProfile}/{LC}/Directory/Users/filterBy" +
+                  $"?filterAttribute={EntryAttribute.sAMAccountName}&filterValue=james.dockers" +
+                  $"&secondFilterAttribute=givenName&secondFilterValue=James" +
+                  $"&combineFilters=true&requiredAttributes={RequiredEntryAttributes.Minimun}";
+
+        // Act
+        var response = await _client.GetAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<LDAPSearchResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+        Assert.NotEmpty(result.Entries);
+    }
+
+    /// <summary>
+    /// A user filter that matches no entries returns 200 OK with empty collection.
+    /// </summary>
+    [Fact]
+    public async Task GetUsersFilteringBy_NoMatch_ReturnsOkWithEmptyEntries()
+    {
+        // Arrange
+        var url = $"api/{ServerProfile}/{LC}/Directory/Users/filterBy" +
+                  $"?filterAttribute={EntryAttribute.sAMAccountName}&filterValue=zzz_no_one_here&requiredAttributes={RequiredEntryAttributes.Minimun}";
+
+        // Act
+        var response = await _client.GetAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<LDAPSearchResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+        Assert.Empty(result.Entries);
+    }
+    #endregion
+
+    #region GET …/Directory/Users/{identifier}/Parents   (GetParentsForUserIdentifier)
+    /// <summary>
+    /// Retrieving parent groups for james.dockers (who is member of DomainAdmins, ITAdmins,
+    /// DevOpsEng, SeniorDevOps, DevOpsLeaders) should return at least one entry.
+    /// </summary>
+    [Fact]
+    public async Task GetParentsForUserIdentifier_ExistingUser_BySAMAccountName_ReturnsParents()
+    {
+        // Arrange
+        var url = $"api/{ServerProfile}/{LC}/Directory/Users/james.dockers/Parents" +
+                  $"?identifierAttribute={EntryAttribute.sAMAccountName}&requiredAttributes={RequiredEntryAttributes.Few}";
+
+        // Act
+        var response = await _client.GetAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<LDAPSearchResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+        Assert.NotEmpty(result.Entries);
+    }
+
+    /// <summary>
+    /// Retrieving parents for a user that has no group memberships or does not exist
+    /// returns 200 OK with an empty entries list (not 404 – the controller does not throw
+    /// ResourceNotFoundException for this endpoint).
+    /// </summary>
+    [Fact]
+    public async Task GetParentsForUserIdentifier_NonExistentUser_ReturnsNotFound()
+    {
+        // Arrange
+        var url = $"api/{ServerProfile}/{LC}/Directory/Users/ghost.nobody/Parents" +
+                  $"?identifierAttribute={EntryAttribute.sAMAccountName}&requiredAttributes={RequiredEntryAttributes.Minimun}";
+
+        // Act
+        var response = await _client.GetAsync(url);
+
+        // Assert
+        // The DirectoryController.GetParentsForUserIdentifier does not 404 on empty results
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        var result = await response.Content.ReadAsStringAsync();
+        Assert.NotNull(result);
+        Assert.Contains("IsMiddlewareException", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Parent entries for ken.master should include the Administrators group
+    /// (seeded in the mock data: ken.master is member of Administrators).
+    /// </summary>
+    [Fact]
+    public async Task GetParentsForUserIdentifier_UserWithAdminGroup_ReturnsAdministratorsAmongParents()
+    {
+        // Arrange
+        var url = $"api/{ServerProfile}/{LC}/Directory/Users/ken.master/Parents" +
+                  $"?identifierAttribute={EntryAttribute.sAMAccountName}&requiredAttributes={RequiredEntryAttributes.Few}";
+
+        // Act
+        var response = await _client.GetAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<LDAPSearchResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+        Assert.NotEmpty(result.Entries);
+        Assert.Contains(result.Entries,
+            e => e.samAccountName != null &&
+                 e.samAccountName.Contains("Administrators", StringComparison.OrdinalIgnoreCase));
+    }
+    #endregion
+
+    #region GET …/Directory/Groups/{identifier}   (GetGroupByIdentifier)
+    /// <summary>
+    /// Retrieve a known group by sAMAccountName (DomainAdmins).
+    /// </summary>
+    [Fact]
+    public async Task GetGroupByIdentifier_ExistingGroup_BySAMAccountName_ReturnsOkWithGroup()
+    {
+        // Arrange
+        var url = $"api/{ServerProfile}/{LC}/Directory/Groups/DomainAdmins" +
+                  $"?identifierAttribute={EntryAttribute.sAMAccountName}&requiredAttributes={RequiredEntryAttributes.Few}";
+
+        // Act
+        var response = await _client.GetAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<LDAPSearchResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+        Assert.Single(result.Entries);
+        Assert.Equal("DomainAdmins", result.Entries.First().samAccountName, ignoreCase: true);
+    }
+
+    /// <summary>
+    /// Retrieve a group by its distinguishedName.
+    /// </summary>
+    [Fact]
+    public async Task GetGroupByIdentifier_ExistingGroup_ByDistinguishedName_ReturnsOkWithGroup()
+    {
+        // Arrange
+        const string dn = "CN=Domain Admins,CN=Users,DC=holding,DC=latam,DC=com";
+        var url = $"api/{ServerProfile}/{LC}/Directory/Groups/{Uri.EscapeDataString(dn)}" +
+                  $"?identifierAttribute={EntryAttribute.distinguishedName}&requiredAttributes={RequiredEntryAttributes.Few}";
+
+        // Act
+        var response = await _client.GetAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<LDAPSearchResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+        Assert.Single(result.Entries);
+        Assert.Equal(dn, result.Entries.First().distinguishedName, ignoreCase: true);
+    }
+
+    /// <summary>
+    /// A sAMAccountName that does not correspond to any group should return 404 Not Found.
+    /// </summary>
+    [Fact]
+    public async Task GetGroupByIdentifier_NonExistentGroup_ReturnsNotFound()
+    {
+        // Arrange
+        var url = $"api/{ServerProfile}/{LC}/Directory/Groups/NonExistentGroup999" +
+                  $"?identifierAttribute={EntryAttribute.sAMAccountName}&requiredAttributes={RequiredEntryAttributes.Minimun}";
+
+        // Act
+        var response = await _client.GetAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+    #endregion
+
+    #region GET …/Directory/Groups/{identifier}/Parents  (GetParentsForGroupIdentifier)
+    /// <summary>
+    /// Retrieve the parent groups of SeniorDevOps.
+    /// Mock data nesting: SeniorDevOps → DevOpsEng → ITAdmins → DomainAdmins → Administrators
+    /// so at least one parent should be returned.
+    /// </summary>
+    [Fact]
+    public async Task GetParentsForGroupIdentifier_ExistingGroup_ReturnsParents()
+    {
+        // Arrange
+        var url = $"api/{ServerProfile}/{LC}/Directory/Groups/SeniorDevOps/Parents" +
+                  $"?identifierAttribute={EntryAttribute.sAMAccountName}&requiredAttributes={RequiredEntryAttributes.Few}";
+
+        // Act
+        var response = await _client.GetAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<LDAPSearchResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+        Assert.NotEmpty(result.Entries);
+    }
+
+    /// <summary>
+    /// Retrieve parents for a group that has no memberOf attribute or does not exist.
+    /// The endpoint returns 200 OK with an empty entries list.
+    /// </summary>
+    [Fact]
+    public async Task GetParentsForGroupIdentifier_NonExistentGroup_ReturnsNotFound()
+    {
+        // Arrange
+        var url = $"api/{ServerProfile}/{LC}/Directory/Groups/NoSuchGroup/Parents" +
+                  $"?identifierAttribute={EntryAttribute.sAMAccountName}&requiredAttributes={RequiredEntryAttributes.Minimun}";
+
+        // Act
+        var response = await _client.GetAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        var result = await response.Content.ReadAsStringAsync();
+        Assert.NotNull(result);
+        Assert.Contains("IsMiddlewareException", result, StringComparison.OrdinalIgnoreCase);
+    }
+    #endregion
+
+    #region GET …/Directory/Groups/filterBy   (GetGroupsFilteringByAsync)
+    /// <summary>
+    /// Filter groups by sAMAccountName containing "DevOps" – expects DevOpsEng, SeniorDevOps,
+    /// JuniorDevOps, DevOpsLeaders to be returned.
+    /// </summary>
+    [Fact]
+    public async Task GetGroupsFilteringBy_WildcardFilter_ReturnsMatchingGroups()
+    {
+        // Arrange
+        var url = $"api/{ServerProfile}/{LC}/Directory/Groups/filterBy" +
+                  $"?filterAttribute={EntryAttribute.sAMAccountName}&filterValue=*DevOps*&requiredAttributes={RequiredEntryAttributes.Few}";
+
+        // Act
+        var response = await _client.GetAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<LDAPSearchResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+        Assert.NotEmpty(result.Entries);
+        Assert.All(result.Entries, e =>
+            Assert.Contains("DevOps", e.samAccountName ?? "", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Filter groups using two attributes combined with AND – both conditions must match
+    /// the same entry.
+    /// </summary>
+    [Fact]
+    public async Task GetGroupsFilteringBy_TwoFiltersAnd_ReturnsOnlyFullyMatchingGroups()
+    {
+        // Arrange: sAMAccountName=SeniorDevOps AND cn=Senior DevOps
+        var url = $"api/{ServerProfile}/{LC}/Directory/Groups/filterBy" +
+                  $"?filterAttribute={EntryAttribute.sAMAccountName}&filterValue=SeniorDevOps" +
+                  $"&secondFilterAttribute=cn&secondFilterValue=Senior DevOps" +
+                  $"&combineFilters=true&requiredAttributes={RequiredEntryAttributes.Few}";
+
+        // Act
+        var response = await _client.GetAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<LDAPSearchResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+        Assert.NotEmpty(result.Entries);
+        Assert.All(result.Entries, e =>
+            Assert.Equal("SeniorDevOps", e.samAccountName, ignoreCase: true));
+    }
+
+    /// <summary>
+    /// Filter groups that do not match anything returns 200 OK with empty entries.
+    /// </summary>
+    [Fact]
+    public async Task GetGroupsFilteringBy_NoMatch_ReturnsOkWithEmptyEntries()
+    {
+        // Arrange
+        var url = $"api/{ServerProfile}/{LC}/Directory/Groups/filterBy" +
+                  $"?filterAttribute={EntryAttribute.sAMAccountName}&filterValue=ZZZ_NonExistentGroup&requiredAttributes={RequiredEntryAttributes.Minimun}";
+
+        // Act
+        var response = await _client.GetAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<LDAPSearchResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+        Assert.Empty(result.Entries);
+    }
+    #endregion
+
+    #region POST …/Directory/MsADUsers   (CreateUserAccountForMsAD)
+    /// <summary>
+    /// Creating a new user account in the local catalog should return 500 InternalServerError
+    /// with a usuccessful operation result.
+    /// </summary>
+    [Fact]
+    public async Task CreateUserAccountForMsAD_NewUser_LocalCatalog_ReturnsInternalServerError()
+    {
+        var newId = Guid.NewGuid().ToString("N")[..8];
+
+        // Arrange – DiplayName and ObjectClass are not provided, which should cause the controller to throw an exception
+        var newUser = new LDAPMsADUserAccount
+        {
+            SAMAccountName = $"test.newuser.{newId}",
+            GivenName = "Test",
+            Sn = $"NewUser {newId}",
+            Cn = $"Test NewUser {newId}",
+            Password = "TestP@ssword1!",
+            DistinguishedNameOfContainer = "OU=Juniors,OU=DevOps,OU=IT,DC=holding,DC=latam,DC=com"
+        };
+        var url = $"api/{ServerProfile}/{LC}/Directory/MsADUsers";
+
+        // Act
+        var response = await _client.PostAsJsonAsync(url, newUser);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var result = await response.Content.ReadAsStringAsync();
+        Assert.Contains(nameof(WebApi.Server.MiddlewareExceptionModel.IsMiddlewareException), result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Creating a new user account in the local catalog should return 200 OK with a
+    /// successful operation result.
+    /// </summary>
+    [Fact]
+    public async Task CreateUserAccountForMsAD_NewUser_LocalCatalog_ReturnsOk()
+    {
+        var newId = Guid.NewGuid().ToString("N")[..8];
+
+        // Arrange – use a unique SAMAccountName to avoid conflicts with seeded data
+        var newUser = new LDAPMsADUserAccount
+        {
+            SAMAccountName = $"test.newuser.{newId}",
+            GivenName = "Test",
+            Sn = $"NewUser {newId}",
+            Cn = $"Test NewUser {newId}",
+            DisplayName = $"Test NewUser {newId} (xUnit)",
+            Password = "TestP@ssword1!",
+            DistinguishedNameOfContainer = "OU=Juniors,OU=DevOps,OU=IT,DC=holding,DC=latam,DC=com",
+            ObjectClass = new[] { "top", "person", "organizationalPerson", "user" }
+        };
+        var url = $"api/{ServerProfile}/{LC}/Directory/MsADUsers";
+
+        // Act
+        var response = await _client.PostAsJsonAsync(url, newUser);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<LDAPCreateMsADUserAccountResult>();
+        Assert.Contains($"MS AD user account created at CN=Test NewUser {newId}", result.OperationMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.True(result.IsSuccessfulOperation);
+    }
+
+    /// <summary>
+    /// Attempting to create a user account in the global catalog should return 400 Bad Request
+    /// because the controller explicitly rejects writes to the global catalog.
+    /// </summary>
+    [Fact]
+    public async Task CreateUserAccountForMsAD_UsingGlobalCatalog_ReturnsBadRequest()
+    {
+        // Arrange
+        var newUser = new LDAPMsADUserAccount
+        {
+            SAMAccountName = "gc.blocked.user",
+            GivenName = "GC",
+            Sn = "Blocked",
+            Password = "TestP@ssword1!",
+            DistinguishedNameOfContainer = "OU=Juniors,OU=DevOps,OU=IT,DC=holding,DC=latam,DC=com"
+        };
+        var url = $"api/{ServerProfile}/{GC}/Directory/MsADUsers";
+
+        // Act
+        var response = await _client.PostAsJsonAsync(url, newUser);
+
+        // Assert – the controller throws BadRequestException for global catalog writes
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Creating a user that already exists (same SAMAccountName as seeded victor.bastidas)
+    /// should return 409 Conflict.
+    /// </summary>
+    [Fact]
+    public async Task CreateUserAccountForMsAD_DuplicateSAMAccountName_ReturnsConflict()
+    {
+        // Arrange – victor.bastidas is seeded by MockLdapDataSeeder
+        var duplicateUser = new LDAPMsADUserAccount
+        {
+            SAMAccountName = "victor.bastidas",
+            GivenName = "Victor",
+            Sn = "Bastidas",
+            Cn = "Victor Bastidas",
+            DisplayName = "Victor Bastidas (Duplicate)",
+            Password = "TestP@ssword1!",
+            DistinguishedNameOfContainer = "OU=Seniors,OU=DevOps,OU=IT,DC=holding,DC=latam,DC=com",
+            ObjectClass = new[] { "top", "person", "organizationalPerson", "user" }
+        };
+        var url = $"api/{ServerProfile}/{LC}/Directory/MsADUsers";
+
+        // Act
+        var response = await _client.PostAsJsonAsync(url, duplicateUser);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+    #endregion
+
+    #region PATCH …/Directory/MsADUsers/{identifier}/Credential   (SetUserAccountCredentialForMsAD)
+    /// <summary>
+    /// Setting a new password for a valid user (red.robbin) by sAMAccountName should return 200 OK.
+    /// </summary>
+    [Fact]
+    public async Task SetUserAccountCredentialForMsAD_ValidUser_BySAMAccountName_ReturnsOk()
+    {
+        // Arrange
+        var credential = new LDAPCredential
+        {
+            UserAccount = "red.robbin",
+            Password = "NewTestP@ssword1!"
+        };
+        var url = $"api/{ServerProfile}/{LC}/Directory/MsADUsers/red.robbin/Credential" +
+                  $"?identifierAttribute={EntryAttribute.sAMAccountName}";
+
+        // Act
+        var response = await _client.PatchAsJsonAsync(url, credential);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<LDAPPasswordUpdateResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+    }
+
+    /// <summary>
+    /// Setting a password for a non-existent user should return 404 Not Found.
+    /// </summary>
+    [Fact]
+    public async Task SetUserAccountCredentialForMsAD_NonExistentUser_ReturnsNotFound()
+    {
+        // Arrange
+        var credential = new LDAPCredential
+        {
+            UserAccount = "ghost.nobody",
+            Password = "NewTestP@ssword1!"
+        };
+        var url = $"api/{ServerProfile}/{LC}/Directory/MsADUsers/ghost.nobody/Credential" +
+                  $"?identifierAttribute={EntryAttribute.sAMAccountName}";
+
+        // Act
+        var response = await _client.PatchAsJsonAsync(url, credential);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Sending a credential with a mismatching user account vs. route identifier should
+    /// return 400 Bad Request.
+    /// </summary>
+    [Fact]
+    public async Task SetUserAccountCredentialForMsAD_AccountMismatch_ReturnsBadRequest()
+    {
+        // Arrange – route says "red.robbin" but credential says "james.dockers"
+        var credential = new LDAPCredential
+        {
+            UserAccount = "HOLDING\\james.dockers",  // domain\account format triggers domain validation
+            Password = "NewTestP@ssword1!"
+        };
+        // Route identifier is different from credential
+        var url = $"api/{ServerProfile}/{LC}/Directory/MsADUsers/red.robbin/Credential" +
+                  $"?identifierAttribute={EntryAttribute.sAMAccountName}";
+
+        // Act
+        var response = await _client.PatchAsJsonAsync(url, credential);
+
+        // Assert – controller validates identifier matches credential account
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+    #endregion
+
+    #region PATCH …/Directory/MsADUsers/{identifier}/disableBy   (DisableMsADUserAccount)
+    /// <summary>
+    /// Disabling a user account (magic.cuy from PE domain, seeded as intern) by sAMAccountName
+    /// should return 200 OK with a successful result.
+    ///
+    /// Note: magic.cuy is seeded under DC=pe,DC=latam,DC=com but the HOLDING profile BaseDN
+    /// is DC=holding,DC=latam,DC=com.  When the mock adapter is used it operates on all entries
+    /// in the in-memory store regardless of BaseDN, so the user is still reachable.
+    /// We therefore use robert.miller who is under DC=holding,DC=latam,DC=com.
+    /// </summary>
+    [Fact]
+    public async Task DisableMsADUserAccount_ValidUser_BySAMAccountName_ReturnsOk()
+    {
+        // Arrange – robert.miller is a HOLDING intern (seeded in the mock store)
+        var url = $"api/{ServerProfile}/{LC}/Directory/MsADUsers/robert.miller/disableBy" +
+                  $"?identifierAttribute={EntryAttribute.sAMAccountName}";
+
+        // Act
+        var response = await _client.PatchAsync(url, null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<LDAPDisableUserAccountOperationResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+    }
+
+    /// <summary>
+    /// Disabling a user via the global catalog should return 400 Bad Request because the
+    /// controller explicitly blocks write operations on the global catalog.
+    /// </summary>
+    [Fact]
+    public async Task DisableMsADUserAccount_UsingGlobalCatalog_ReturnsBadRequest()
+    {
+        // Arrange
+        var url = $"api/{ServerProfile}/{GC}/Directory/MsADUsers/robert.miller/disableBy" +
+                  $"?identifierAttribute={EntryAttribute.sAMAccountName}";
+
+        // Act
+        var response = await _client.PatchAsync(url, null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Disabling a non-existent user should return 404 Not Found.
+    /// </summary>
+    [Fact]
+    public async Task DisableMsADUserAccount_NonExistentUser_ReturnsNotFound()
+    {
+        // Arrange
+        var url = $"api/{ServerProfile}/{LC}/Directory/MsADUsers/nonexistent.person/disableBy" +
+                  $"?identifierAttribute={EntryAttribute.sAMAccountName}";
+
+        // Act
+        var response = await _client.PatchAsync(url, null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+    #endregion
+
+    #region DELETE …/Directory/MsADUsers/{identifier}   (RemoveMsADUserAccount)
+    /// <summary>
+    /// Removing a user (magic.cuy, seeded as PE intern) by sAMAccountName
+    /// should return 200 OK.
+    /// We use alice.wonder who is under DC=holding,DC=latam,DC=com.
+    /// </summary>
+    [Fact]
+    public async Task RemoveMsADUserAccount_ValidUser_BySAMAccountName_ReturnsOk()
+    {
+        // Arrange – alice.wonder is seeded under OU=Support,OU=IT,DC=holding,...
+        var url = $"api/{ServerProfile}/{LC}/Directory/MsADUsers/alice.wonder" +
+                  $"?identifierAttribute={EntryAttribute.sAMAccountName}";
+
+        // Act
+        var response = await _client.DeleteAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<LDAPRemoveMsADUserAccountResult>();
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccessfulOperation);
+    }
+
+    /// <summary>
+    /// Attempting to remove a user via the global catalog should return 400 Bad Request.
+    /// </summary>
+    [Fact]
+    public async Task RemoveMsADUserAccount_UsingGlobalCatalog_ReturnsBadRequest()
+    {
+        // Arrange
+        var url = $"api/{ServerProfile}/{GC}/Directory/MsADUsers/alice.wonder" +
+                  $"?identifierAttribute={EntryAttribute.sAMAccountName}";
+
+        // Act
+        var response = await _client.DeleteAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Removing a non-existent user should return 404 Not Found.
+    /// </summary>
+    [Fact]
+    public async Task RemoveMsADUserAccount_NonExistentUser_ReturnsNotFound()
+    {
+        // Arrange
+        var url = $"api/{ServerProfile}/{LC}/Directory/MsADUsers/no.such.person" +
+                  $"?identifierAttribute={EntryAttribute.sAMAccountName}";
+
+        // Act
+        var response = await _client.DeleteAsync(url);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+    #endregion
+
+    #region Route constraint validation
+    /// <summary>
+    /// Any endpoint with an unknown server profile should be rejected by the
+    /// <c>ldapSvrPf</c> route constraint returning 404.
+    /// </summary>
+    [Fact]
+    public async Task AnyEndpoint_UnknownServerProfile_ReturnsNotFound()
+    {
+        var url = $"api/UNKNOWN_PROFILE/{LC}/Directory/james.dockers?identifierAttribute={EntryAttribute.sAMAccountName}";
+        var response = await _client.GetAsync(url);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Any endpoint with an unknown catalog type should be rejected by the
+    /// <c>ldapCatType</c> route constraint returning 404.
+    /// </summary>
+    [Fact]
+    public async Task AnyEndpoint_UnknownCatalogType_ReturnsNotFound()
+    {
+        var url = $"api/{ServerProfile}/INVALID_CATALOG/Directory/james.dockers?identifierAttribute={EntryAttribute.sAMAccountName}";
+        var response = await _client.GetAsync(url);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+    #endregion
+}

--- a/tests/Bitai.LDAPWebApi.Tests/Infrastructure/LDAPWebApiFactory.cs
+++ b/tests/Bitai.LDAPWebApi.Tests/Infrastructure/LDAPWebApiFactory.cs
@@ -1,0 +1,57 @@
+using Bitai.LDAPWebApi.Configurations.App;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Bitai.LDAPWebApi.Tests.Infrastructure;
+
+/// <summary>
+/// A custom <see cref="Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory{TEntryPoint}"/>
+/// that boots the full ASP.NET Core pipeline using the application's own <see cref="Startup"/>,
+/// overlaying test-specific configuration (appsettings.Tests.json) so that
+/// <see cref="WebApiConfiguration.WebApiTestConfiguration.EnablePersistentMockLdapDataStore"/>
+/// is <c>true</c>. This causes the DI container to register
+/// <see cref="Bitai.LDAPHelper.Tests.Mocks.LdapAdapters.MockLdapPersistentConnectionFactoryAdapter"/>
+/// instead of the real Novell LDAP adapter, and the middleware seeds the mock LDAP data store.
+/// </summary>
+public class LDAPWebApiFactory : Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<Startup>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        // Point at the test project directory so relative paths in configuration work.
+        builder.UseContentRoot(Directory.GetCurrentDirectory());
+
+        // Overlay the standard appsettings with the test-specific one.
+        builder.ConfigureAppConfiguration((context, config) =>
+        {
+            // Remove the existing sources added by the host builder so we control the order.
+            config.Sources.Clear();
+
+            config.SetBasePath(Directory.GetCurrentDirectory())
+                  .AddJsonFile("appsettings.Tests.json", optional: false, reloadOnChange: false);
+        });
+
+        //// Use the application's own Startup class so we exercise real service registration
+        //// and middleware. The Startup.ConfigureServices call picks up
+        //// WebApiConfiguration.TestConfiguration.EnablePersistentMockLdapDataStore = true
+        //// from appsettings.Tests.json and registers the mock LDAP adapter automatically.
+        //builder.Configure(app =>
+        //{
+        //    // Intentionally empty – the real pipeline is configured by Startup.Configure,
+        //    // which is invoked because we are using UseStartup<Startup>() below.
+        //});
+
+        //builder.UseStartup<Startup>();
+
+        // Suppress Serilog bootstrap (it tries to configure a static logger that conflicts
+        // with parallel test runs). We rely on the Microsoft ILogger registered by ASP.NET Core.
+        builder.ConfigureLogging(logging =>
+        {
+            logging.ClearProviders();
+            logging.AddConsole();
+            logging.SetMinimumLevel(LogLevel.Information);
+        });
+    }
+}

--- a/tests/Bitai.LDAPWebApi.Tests/appsettings.Tests.json
+++ b/tests/Bitai.LDAPWebApi.Tests/appsettings.Tests.json
@@ -1,0 +1,85 @@
+{
+  "AllowedHosts": "*",
+  "WebApiConfiguration": {
+    "HealthChecksConfiguration": {
+      "EnableHealthChecks": false,
+      "WebApiBaseUrl": "https://localhost:5101",
+      "EvaluationTime": 60
+    },
+    "TestConfiguration": {
+      "EnablePersistentMockLdapDataStore": true
+    }
+  },
+  "WebApiCorsConfiguration": {
+    "AllowAnyOrigin": false,
+    "AllowedOrigins": []
+  },
+  "WebApiLogConfiguration": {
+    "ConsoleLog": {
+      "Enabled": true,
+      "MinimunLogEventLevel": "Information"
+    },
+    "FileLog": {
+      "Enabled": false,
+      "LogFilePath": "./logs/Bitai.LDAPWebApi.Tests-.log",
+      "MinimunLogEventLevel": "Information"
+    },
+    "GrafanaLokiLog": {
+      "Enabled": false,
+      "LokiUrl": "http://localhost:3100",
+      "BatchPostingLimit": 100,
+      "Period": "00:00:02",
+      "AppName": "Bitai.LDAPWebApi.Tests",
+      "MinimunLogEventLevel": "Warning"
+    },
+    "ElasticsearchLog": {
+      "Enabled": false,
+      "ElasticsearchNodeUrls": [ "http://localhost:9200" ],
+      "MinimunLogEventLevel": "Warning"
+    }
+  },
+  "WebApiScopesConfiguration": {
+    "BypassApiScopesAuthorization": true,
+    "AdminApiScopeName": "Bitai.LdapWebApi.Tests.ApiScope.Admin",
+    "ReaderApiScopeName": "Bitai.LdapWebApi.Tests.ApiScope.Reader"
+  },
+  "AuthorityConfiguration": {
+    "Authority\": \"https": null, //localhost/IsSts9",
+    "ApiResource": "Bitai.LdapWebApi.Tests.ApiResource",
+    "RequireHttpsMetadata": true
+  },
+  "LDAPServerProfiles": [
+    {
+      "ProfileId": "HOLDING",
+      "Server": "mock-ldap.latam.com",
+      "Port": "Default",
+      "UseSSL": "false",
+      "BaseDN": "DC=holding,DC=latam,DC=com",
+      "PortForGlobalCatalog": "Default",
+      "UseSSLforGlobalCatalog": "false",
+      "BaseDNforGlobalCatalog": "DC=latam,DC=com",
+      "DefaultDomainName": "HOLDING",
+      "ConnectionTimeout": "10",
+      "DomainUserAccount": "HOLDING\\Administrator",
+      "DomainAccountPassword": "TestP@ssword!",
+      "HealthCheckPingTimeout": 10
+    }
+  ],
+  "SwaggerUIConfiguration": {
+    "SwaggerUIClientId": "Bitai.LdapWebApi.Tests.Swagger.Client",
+    "SwaggerUITargetApiScopes": [
+      {
+        "SwaggerUITargetApiScopeName": "Bitai.LdapWebApi.Tests.ApiScope.Reader",
+        "SwaggerUITargetApiScopeTitle": "BITAI LDAP Web Api Reader Scope"
+      },
+      {
+        "SwaggerUITargetApiScopeName": "Bitai.LdapWebApi.Tests.ApiScope.Admin",
+        "SwaggerUITargetApiScopeTitle": "BITAI LDAP Web Api Admin Scope"
+      },
+      {
+        "SwaggerUITargetApiScopeName": "Bitai.LdapWebApi.Tests.ApiScope.Dummy",
+        "SwaggerUITargetApiScopeTitle": "BITAI LDAP Web Api Dummy Scope"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add CI workflow and integration tests for LDAPWebApi

Introduced a GitHub Actions workflow for .NET 10.0 build and test automation. Added a new test project with xUnit and coverlet, including comprehensive integration tests for authentication and directory endpoints using a persistent mock LDAP data store. Implemented a custom WebApplicationFactory to support test configuration and logging.

## Summary by Sourcery

Add integration test infrastructure and CI workflow for LDAPWebApi, introduce mock LDAP data seeding for test mode, and refine authentication/directory APIs, configuration, and logging for better error handling and testability.

New Features:
- Introduce xUnit-based integration test project for LDAPWebApi controllers using a custom WebApplicationFactory and persistent mock LDAP data store.
- Add a new authentication endpoint that validates domain credentials without performing a prior user lookup.
- Expose client-side support for the new authenticateWithoutUserLookup API in the LDAP WebApi client library.

Bug Fixes:
- Normalize exception handling in directory operations to wrap LDAP and validation errors into consistent HTTP responses, including proper 404, 400, and 409 mappings.
- Fix domain and username validation when setting user credentials to ensure route identifiers and payload accounts match and return appropriate errors.
- Correct various configuration and logging typos and messages to improve clarity (e.g., error texts and log labels).

Enhancements:
- Refactor Program and Startup to a more conventional host builder pattern and centralize logger setup with Serilog enrichers and sinks.
- Make LDAP connection factory registration configurable to switch between real Novell LDAP and mock persistent LDAP based on test configuration.
- Simplify user account operations (create, disable, remove, set password) by delegating identifier resolution to the account manager API instead of manual LDAP searches.
- Tighten default CORS configuration and expand Swagger UI configuration for multiple API scopes.
- Improve logging around authentication and directory endpoints with clearer endpoint metadata and payload logging.

Build:
- Add a GitHub Actions CI workflow to restore, build, and test the solution on .NET 10.0 across pushes, PRs, and manual runs.

Tests:
- Add extensive integration tests for DirectoryController covering identifier-based queries, filtering, group/user parent resolution, and user account lifecycle operations against the mock LDAP store.
- Add integration tests for AuthenticationsController validating successful and failing authentication scenarios, catalog type behavior, and route constraints.
- Introduce a custom WebApplicationFactory that boots the real Startup pipeline with test-specific configuration enabling the mock LDAP data store.